### PR TITLE
Update spark examples

### DIFF
--- a/examples/ecp-5.3.0/2.4.4/advancedsamples/pyspark-with-dependencies.yaml
+++ b/examples/ecp-5.3.0/2.4.4/advancedsamples/pyspark-with-dependencies.yaml
@@ -1,0 +1,66 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "sparkoperator.hpe.com/v1beta2"
+kind: SparkApplication
+metadata:
+  name: pyspark-with-dependencies
+  namespace: sampletenant
+spec:
+  #sparkConf:
+    # Note: If you are executing the application as a K8 user that MapR can verify,
+    #       you do not need to specify a spark.mapr.user.secret
+    #spark.mapr.user.secret: spark-user-secret
+    # Note: You do not need to specify a spark.eventLog.dir
+    #       it will be auto-generated with the pattern "maprfs:///apps/spark/<namespace>"
+    #spark.eventLog.dir: "maprfs:///apps/spark/sampletenant"
+  type: Python
+  sparkVersion: 2.4.4
+  pythonVersion: "3"
+  mode: cluster
+  image: gcr.io/mapr-252711/spark-py-2.4.4:202009090453C
+  imagePullPolicy: Always
+  mainApplicationFile: local:///maprfs-csi/path/to/main/file/app.py
+  deps:
+    pyFiles:
+      - local:///maprfs-csi/path/to/dependency.py
+  restartPolicy:
+    type: Never
+  imagePullSecrets:
+  - imagepull
+  driver:
+    cores: 1
+    coreLimit: "1000m"
+    memory: "512m"
+    labels:
+      version: 2.4.4
+    # Note: You do not need to specify a serviceAccount
+    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
+    #serviceAccount: hpe-sampletenant
+    volumeMounts:
+      - name: maprfs-volume
+        mountPath: /maprfs-csi
+  executor:
+    cores: 1
+    coreLimit: "1000m"
+    instances: 2
+    memory: "512m"
+    labels:
+      version: 2.4.4
+  volumes:
+  - name: maprfs-volume
+    persistentVolumeClaim:
+      claimName: mapr-csi-pvc

--- a/examples/ecp-5.3.0/2.4.4/advancedsamples/spark-affinity-pi.yaml
+++ b/examples/ecp-5.3.0/2.4.4/advancedsamples/spark-affinity-pi.yaml
@@ -1,0 +1,74 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "sparkoperator.hpe.com/v1beta2"
+kind: SparkApplication
+metadata:
+  name: spark-pi
+  namespace: sampletenant
+spec:
+  #sparkConf:
+    # Note: If you are executing the application as a K8 user that MapR can verify,
+    #       you do not need to specify a spark.mapr.user.secret
+    #spark.mapr.user.secret: spark-user-secret
+    # Note: You do not need to specify a spark.eventLog.dir
+    #       it will be auto-generated with the pattern "maprfs:///apps/spark/<namespace>"
+    #spark.eventLog.dir: "maprfs:///apps/spark/sampletenant"
+  type: Scala
+  sparkVersion: 2.4.4
+  mode: cluster
+  image: gcr.io/mapr-252711/spark-2.4.4:202009090453C
+  imagePullPolicy: Always
+  mainClass: org.apache.spark.examples.SparkPi
+  mainApplicationFile: "local:///opt/mapr/spark/spark-2.4.4/examples/jars/spark-examples_2.11-2.4.4.6-mapr-630.jar"
+  restartPolicy:
+    type: Never
+  imagePullSecrets:
+  - imagepull
+  driver:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: compute
+              operator: In
+              values:
+              - node1
+    cores: 1
+    coreLimit: "1000m"
+    memory: "512m"
+    labels:
+      version: 2.4.4
+    # Note: You do not need to specify a serviceAccount
+    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
+    #serviceAccount: hpe-sampletenant
+  executor:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: compute
+              operator: In
+              values:
+              - node2
+    cores: 1
+    coreLimit: "1000m"
+    instances: 2
+    memory: "512m"
+    labels:
+      version: 2.4.4

--- a/examples/ecp-5.3.0/2.4.4/advancedsamples/spark-aws-s3a-wc.yaml
+++ b/examples/ecp-5.3.0/2.4.4/advancedsamples/spark-aws-s3a-wc.yaml
@@ -1,0 +1,64 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "sparkoperator.hpe.com/v1beta2"
+kind: SparkApplication
+metadata:
+  name: spark-aws-s3a-wordcount
+  namespace: sampletenant
+spec:
+  #sparkConf:
+    # Note: If you are executing the application as a K8 user that MapR can verify,
+    #       you do not need to specify a spark.mapr.user.secret
+    #spark.mapr.user.secret: spark-user-secret
+    # Note: You do not need to specify a spark.eventLog.dir
+    #       it will be auto-generated with the pattern "maprfs:///apps/spark/<namespace>"
+    #spark.eventLog.dir: "maprfs:///apps/spark/sampletenant"
+  hadoopConf:
+    fs.s3a.endpoint: "sts.amazonaws.com"
+    fs.s3a.access.key: "accessKey1"
+    fs.s3a.secret.key: "secretKey1"
+    fs.s3a.path.style.access: "true"
+    fs.s3a.impl: "org.apache.hadoop.fs.s3a.S3AFileSystem"
+  type: Scala
+  sparkVersion: 2.4.4
+  mode: cluster
+  image: gcr.io/mapr-252711/spark-2.4.4:202009090453C
+  imagePullPolicy: Always
+  mainClass: org.apache.spark.examples.JavaWordCount
+  mainApplicationFile: "local:///opt/mapr/spark/spark-2.4.4/examples/jars/spark-examples_2.11-2.4.4.6-mapr-630.jar"
+  restartPolicy:
+    type: Never
+  arguments:
+  - s3a://mybucket/input.txt
+  imagePullSecrets:
+  - imagepull
+  driver:
+    cores: 1
+    coreLimit: "1000m"
+    memory: "512m"
+    labels:
+      version: 2.4.4
+    # Note: You do not need to specify a serviceAccount
+    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
+    #serviceAccount: hpe-sampletenant
+  executor:
+    cores: 1
+    coreLimit: "1000m"
+    instances: 2
+    memory: "512m"
+    labels:
+      version: 2.4.4

--- a/examples/ecp-5.3.0/2.4.4/pyspark-wc.yaml
+++ b/examples/ecp-5.3.0/2.4.4/pyspark-wc.yaml
@@ -1,0 +1,58 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "sparkoperator.hpe.com/v1beta2"
+kind: SparkApplication
+metadata:
+  name: pyspark-wordcount-secure
+  namespace: sampletenant
+spec:
+  #sparkConf:
+    # Note: If you are executing the application as a K8 user that MapR can verify,
+    #       you do not need to specify a spark.mapr.user.secret
+    #spark.mapr.user.secret: spark-user-secret
+    # Note: You do not need to specify a spark.eventLog.dir
+    #       it will be auto-generated with the pattern "maprfs:///apps/spark/<namespace>"
+    #spark.eventLog.dir: "maprfs:///apps/spark/sampletenant"
+  type: Python
+  sparkVersion: 2.4.4
+  pythonVersion: "3"
+  mode: cluster
+  image: gcr.io/mapr-252711/spark-py-2.4.4:202009090453C
+  imagePullPolicy: Always
+  mainApplicationFile: local:///opt/mapr/spark/spark-2.4.4/examples/src/main/python/wordcount.py
+  restartPolicy:
+    type: Never
+  arguments:
+  - maprfs:///tmp/input.txt
+  imagePullSecrets:
+  - imagepull
+  driver:
+    cores: 1
+    coreLimit: "1000m"
+    memory: "512m"
+    labels:
+      version: 2.4.4
+    # Note: You do not need to specify a serviceAccount
+    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
+    #serviceAccount: hpe-sampletenant
+  executor:
+    cores: 1
+    coreLimit: "1000m"
+    instances: 2
+    memory: "512m"
+    labels:
+      version: 2.4.4

--- a/examples/ecp-5.3.0/2.4.4/r-spark-naive-bayes.yaml
+++ b/examples/ecp-5.3.0/2.4.4/r-spark-naive-bayes.yaml
@@ -1,0 +1,55 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "sparkoperator.hpe.com/v1beta2"
+kind: SparkApplication
+metadata:
+  name: sparkr-naive-bayes-secure
+  namespace: sampletenant
+spec:
+  #sparkConf:
+    # Note: If you are executing the application as a K8 user that MapR can verify,
+    #       you do not need to specify a spark.mapr.user.secret
+    #spark.mapr.user.secret: spark-user-secret
+    # Note: You do not need to specify a spark.eventLog.dir
+    #       it will be auto-generated with the pattern "maprfs:///apps/spark/<namespace>"
+    #spark.eventLog.dir: "maprfs:///apps/spark/sampletenant"
+  type: R
+  sparkVersion: 2.4.4
+  mode: cluster
+  image: gcr.io/mapr-252711/spark-r-2.4.4:202009090453C
+  imagePullPolicy: Always
+  mainApplicationFile: local:///opt/mapr/spark/spark-2.4.4/examples/src/main/r/ml/naiveBayes.R
+  restartPolicy:
+    type: Never
+  imagePullSecrets:
+  - imagepull
+  driver:
+    cores: 1
+    coreLimit: "1000m"
+    memory: "512m"
+    labels:
+      version: 2.4.4
+    # Note: You do not need to specify a serviceAccount
+    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
+    #serviceAccount: hpe-sampletenant
+  executor:
+    cores: 1
+    coreLimit: "1000m"
+    instances: 2
+    memory: "512m"
+    labels:
+      version: 2.4.4

--- a/examples/ecp-5.3.0/2.4.4/spark-hive.yaml
+++ b/examples/ecp-5.3.0/2.4.4/spark-hive.yaml
@@ -1,0 +1,64 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "sparkoperator.hpe.com/v1beta2"
+kind: SparkApplication
+metadata:
+  name: spark-hive-secure
+  namespace: sampletenant
+spec:
+  #sparkConf:
+    # Note: If you are executing the application as a K8 user that MapR can verify,
+    #       you do not need to specify a spark.mapr.user.secret
+    #spark.mapr.user.secret: spark-user-secret
+    # Note: You do not need to specify a spark.eventLog.dir
+    #       it will be auto-generated with the pattern "maprfs:///apps/spark/<namespace>"
+    #spark.eventLog.dir: "maprfs:///apps/spark/sampletenant"
+  type: Scala
+  sparkVersion: 2.4.4
+  mode: cluster
+  image: gcr.io/mapr-252711/spark-2.4.4:202009090453C
+  imagePullPolicy: Always
+  mainClass: org.apache.spark.examples.sql.hive.SparkHiveExample
+  mainApplicationFile: "local:///opt/mapr/spark/spark-2.4.4/examples/jars/spark-examples_2.11-2.4.4.6-mapr-630.jar"
+  restartPolicy:
+    type: Never
+  imagePullSecrets:
+  - imagepull
+  driver:
+    cores: 1
+    coreLimit: "1000m"
+    memory: "512m"
+    labels:
+      version: 2.4.4
+    volumeMounts:
+    - name: hive-site-volume
+      mountPath: /opt/mapr/spark/spark-2.4.4/conf/hive-site.xml
+      subPath: hive-site.xml
+  executor:
+    cores: 1
+    coreLimit: "1000m"
+    instances: 2
+    memory: "512m"
+    labels:
+      version: 2.4.4
+    # Note: You do not need to specify a serviceAccount
+    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
+    #serviceAccount: hpe-sampletenant
+  volumes:
+  - name: hive-site-volume
+    configMap:
+      name: hivesite-cm

--- a/examples/ecp-5.3.0/2.4.4/spark-pi-scheduled.yaml
+++ b/examples/ecp-5.3.0/2.4.4/spark-pi-scheduled.yaml
@@ -1,0 +1,43 @@
+apiVersion: "sparkoperator.hpe.com/v1beta2"
+kind: ScheduledSparkApplication
+metadata:
+  name: spark-pi-scheduled
+  namespace: sampletenant
+spec:
+  schedule: "@every 1m"
+  concurrencyPolicy: Allow
+  template:
+    #sparkConf:
+      # Note: If you are executing the application as a K8 user that MapR can verify,
+      #       you do not need to specify a spark.mapr.user.secret
+      #spark.mapr.user.secret: spark-user-secret
+      # Note: You do not need to specify a spark.eventLog.dir
+      #       it will be auto-generated with the pattern "maprfs:///apps/spark/<namespace>"
+      #spark.eventLog.dir: "maprfs:///apps/spark/sampletenant"
+    type: Scala
+    sparkVersion: 2.4.4
+    mode: cluster
+    image: gcr.io/mapr-252711/spark-2.4.4:202009090453C
+    imagePullPolicy: Always
+    imagePullSecrets:
+      - imagepull
+    mainClass: org.apache.spark.examples.SparkPi
+    mainApplicationFile: "local:///opt/mapr/spark/spark-2.4.4/examples/jars/spark-examples_2.11-2.4.4.6-mapr-630.jar"
+    restartPolicy:
+      type: Never
+    driver:
+      cores: 1
+      coreLimit: "1000m"
+      memory: "512m"
+      labels:
+        version: 2.4.4
+      # Note: You do not need to specify a serviceAccount
+      #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
+      #serviceAccount: hpe-sampletenant
+    executor:
+      cores: 1
+      coreLimit: "1000m"
+      instances: 1
+      memory: "512m"
+      labels:
+        version: 2.4.4

--- a/examples/ecp-5.3.0/2.4.4/spark-pi.yaml
+++ b/examples/ecp-5.3.0/2.4.4/spark-pi.yaml
@@ -1,0 +1,56 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "sparkoperator.hpe.com/v1beta2"
+kind: SparkApplication
+metadata:
+  name: spark-pi-secure
+  namespace: sampletenant
+spec:
+  #sparkConf:
+    # Note: If you are executing the application as a K8 user that MapR can verify,
+    #       you do not need to specify a spark.mapr.user.secret
+    #spark.mapr.user.secret: spark-user-secret
+    # Note: You do not need to specify a spark.eventLog.dir
+    #       it will be auto-generated with the pattern "maprfs:///apps/spark/<namespace>"
+    #spark.eventLog.dir: "maprfs:///apps/spark/sampletenant"
+  type: Scala
+  sparkVersion: 2.4.4
+  mode: cluster
+  image: gcr.io/mapr-252711/spark-2.4.4:202009090453C
+  imagePullPolicy: Always
+  imagePullSecrets:
+  - imagepull
+  mainClass: org.apache.spark.examples.SparkPi
+  mainApplicationFile: "local:///opt/mapr/spark/spark-2.4.4/examples/jars/spark-examples_2.11-2.4.4.6-mapr-630.jar"
+  restartPolicy:
+    type: Never
+  driver:
+    cores: 1
+    coreLimit: "1000m"
+    memory: "512m"
+    labels:
+      version: 2.4.4
+    # Note: You do not need to specify a serviceAccount
+    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
+    #serviceAccount: hpe-sampletenant
+  executor:
+    cores: 1
+    coreLimit: "1000m"
+    instances: 1
+    memory: "512m"
+    labels:
+      version: 2.4.4

--- a/examples/ecp-5.3.0/2.4.4/spark-streaming-queue.yaml
+++ b/examples/ecp-5.3.0/2.4.4/spark-streaming-queue.yaml
@@ -1,0 +1,56 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "sparkoperator.hpe.com/v1beta2"
+kind: SparkApplication
+metadata:
+  name: spark-streaming-queue-secure
+  namespace: sampletenant
+spec:
+  #sparkConf:
+    # Note: If you are executing the application as a K8 user that MapR can verify,
+    #       you do not need to specify a spark.mapr.user.secret
+    #spark.mapr.user.secret: spark-user-secret
+    # Note: You do not need to specify a spark.eventLog.dir
+    #       it will be auto-generated with the pattern "maprfs:///apps/spark/<namespace>"
+    #spark.eventLog.dir: "maprfs:///apps/spark/sampletenant"
+  type: Scala
+  sparkVersion: 2.4.4
+  mode: cluster
+  image: gcr.io/mapr-252711/spark-2.4.4:202009090453C
+  imagePullPolicy: Always
+  mainClass: org.apache.spark.examples.streaming.QueueStream
+  mainApplicationFile: "local:///opt/mapr/spark/spark-2.4.4/examples/jars/spark-examples_2.11-2.4.4.6-mapr-630.jar"
+  restartPolicy:
+    type: Never
+  imagePullSecrets:
+  - imagepull
+  driver:
+    cores: 1
+    coreLimit: "1000m"
+    memory: "512m"
+    labels:
+      version: 2.4.4
+    # Note: You do not need to specify a serviceAccount
+    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
+    #serviceAccount: hpe-sampletenant
+  executor:
+    cores: 1
+    coreLimit: "1000m"
+    instances: 2
+    memory: "512m"
+    labels:
+      version: 2.4.4

--- a/examples/ecp-5.3.0/2.4.4/spark-wc.yaml
+++ b/examples/ecp-5.3.0/2.4.4/spark-wc.yaml
@@ -1,0 +1,58 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "sparkoperator.hpe.com/v1beta2"
+kind: SparkApplication
+metadata:
+  name: spark-wordcount-secure
+  namespace: sampletenant
+spec:
+  #sparkConf:
+    # Note: If you are executing the application as a K8 user that MapR can verify,
+    #       you do not need to specify a spark.mapr.user.secret
+    #spark.mapr.user.secret: spark-user-secret
+    # Note: You do not need to specify a spark.eventLog.dir
+    #       it will be auto-generated with the pattern "maprfs:///apps/spark/<namespace>"
+    #spark.eventLog.dir: "maprfs:///apps/spark/sampletenant"
+  type: Java
+  sparkVersion: 2.4.4
+  mode: cluster
+  image: gcr.io/mapr-252711/spark-2.4.4:202009090453C
+  imagePullPolicy: Always
+  mainClass: org.apache.spark.examples.JavaWordCount
+  mainApplicationFile: "local:///opt/mapr/spark/spark-2.4.4/examples/jars/spark-examples_2.11-2.4.4.6-mapr-630.jar"
+  restartPolicy:
+    type: Never
+  arguments:
+  - maprfs:///tmp/input.txt
+  imagePullSecrets:
+  - imagepull
+  driver:
+    cores: 1
+    coreLimit: "1000m"
+    memory: "512m"
+    labels:
+      version: 2.4.4
+    # Note: You do not need to specify a serviceAccount
+    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
+    #serviceAccount: hpe-sampletenant
+  executor:
+    cores: 1
+    coreLimit: "1000m"
+    instances: 2
+    memory: "512m"
+    labels:
+      version: 2.4.4

--- a/examples/ecp-5.3.0/2.4.7/advancedsamples/pyspark-with-dependencies.yaml
+++ b/examples/ecp-5.3.0/2.4.7/advancedsamples/pyspark-with-dependencies.yaml
@@ -1,0 +1,66 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "sparkoperator.hpe.com/v1beta2"
+kind: SparkApplication
+metadata:
+  name: pyspark-with-dependencies
+  namespace: sampletenant
+spec:
+  #sparkConf:
+    # Note: If you are executing the application as a K8 user that MapR can verify,
+    #       you do not need to specify a spark.mapr.user.secret
+    #spark.mapr.user.secret: spark-user-secret
+    # Note: You do not need to specify a spark.eventLog.dir
+    #       it will be auto-generated with the pattern "maprfs:///apps/spark/<namespace>"
+    #spark.eventLog.dir: "maprfs:///apps/spark/sampletenant"
+  type: Python
+  sparkVersion: 2.4.7
+  pythonVersion: "3"
+  mode: cluster
+  image: gcr.io/mapr-252711/spark-py-2.4.7:202104010902C
+  imagePullPolicy: Always
+  mainApplicationFile: local:///maprfs-csi/path/to/main/file/app.py
+  deps:
+    pyFiles:
+      - local:///maprfs-csi/path/to/dependency.py
+  restartPolicy:
+    type: Never
+  imagePullSecrets:
+  - imagepull
+  driver:
+    cores: 1
+    coreLimit: "1000m"
+    memory: "512m"
+    labels:
+      version: 2.4.7
+    # Note: You do not need to specify a serviceAccount
+    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
+    #serviceAccount: hpe-sampletenant
+    volumeMounts:
+      - name: maprfs-volume
+        mountPath: /maprfs-csi
+  executor:
+    cores: 1
+    coreLimit: "1000m"
+    instances: 2
+    memory: "512m"
+    labels:
+      version: 2.4.7
+  volumes:
+  - name: maprfs-volume
+    persistentVolumeClaim:
+      claimName: mapr-csi-pvc

--- a/examples/ecp-5.3.0/2.4.7/advancedsamples/spark-affinity-pi.yaml
+++ b/examples/ecp-5.3.0/2.4.7/advancedsamples/spark-affinity-pi.yaml
@@ -1,0 +1,74 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "sparkoperator.hpe.com/v1beta2"
+kind: SparkApplication
+metadata:
+  name: spark-pi
+  namespace: sampletenant
+spec:
+  #sparkConf:
+    # Note: If you are executing the application as a K8 user that MapR can verify,
+    #       you do not need to specify a spark.mapr.user.secret
+    #spark.mapr.user.secret: spark-user-secret
+    # Note: You do not need to specify a spark.eventLog.dir
+    #       it will be auto-generated with the pattern "maprfs:///apps/spark/<namespace>"
+    #spark.eventLog.dir: "maprfs:///apps/spark/sampletenant"
+  type: Scala
+  sparkVersion: 2.4.7
+  mode: cluster
+  image: gcr.io/mapr-252711/spark-2.4.7:202104010902C
+  imagePullPolicy: Always
+  mainClass: org.apache.spark.examples.SparkPi
+  mainApplicationFile: "local:///opt/mapr/spark/spark-2.4.7/examples/jars/spark-examples_2.12-2.4.7.2-mapr-701.jar"
+  restartPolicy:
+    type: Never
+  imagePullSecrets:
+  - imagepull
+  driver:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: compute
+              operator: In
+              values:
+              - node1
+    cores: 1
+    coreLimit: "1000m"
+    memory: "512m"
+    labels:
+      version: 2.4.7
+    # Note: You do not need to specify a serviceAccount
+    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
+    #serviceAccount: hpe-sampletenant
+  executor:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: compute
+              operator: In
+              values:
+              - node2
+    cores: 1
+    coreLimit: "1000m"
+    instances: 2
+    memory: "512m"
+    labels:
+      version: 2.4.7

--- a/examples/ecp-5.3.0/2.4.7/advancedsamples/spark-aws-s3a-wc.yaml
+++ b/examples/ecp-5.3.0/2.4.7/advancedsamples/spark-aws-s3a-wc.yaml
@@ -1,0 +1,64 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "sparkoperator.hpe.com/v1beta2"
+kind: SparkApplication
+metadata:
+  name: spark-aws-s3a-wordcount
+  namespace: sampletenant
+spec:
+  #sparkConf:
+    # Note: If you are executing the application as a K8 user that MapR can verify,
+    #       you do not need to specify a spark.mapr.user.secret
+    #spark.mapr.user.secret: spark-user-secret
+    # Note: You do not need to specify a spark.eventLog.dir
+    #       it will be auto-generated with the pattern "maprfs:///apps/spark/<namespace>"
+    #spark.eventLog.dir: "maprfs:///apps/spark/sampletenant"
+  hadoopConf:
+    fs.s3a.endpoint: "sts.amazonaws.com"
+    fs.s3a.access.key: "accessKey1"
+    fs.s3a.secret.key: "secretKey1"
+    fs.s3a.path.style.access: "true"
+    fs.s3a.impl: "org.apache.hadoop.fs.s3a.S3AFileSystem"
+  type: Scala
+  sparkVersion: 2.4.7
+  mode: cluster
+  image: gcr.io/mapr-252711/spark-2.4.7:202104010902C
+  imagePullPolicy: Always
+  mainClass: org.apache.spark.examples.JavaWordCount
+  mainApplicationFile: "local:///opt/mapr/spark/spark-2.4.7/examples/jars/spark-examples_2.12-2.4.7.2-mapr-701.jar"
+  restartPolicy:
+    type: Never
+  arguments:
+  - s3a://mybucket/input.txt
+  imagePullSecrets:
+  - imagepull
+  driver:
+    cores: 1
+    coreLimit: "1000m"
+    memory: "512m"
+    labels:
+      version: 2.4.7
+    # Note: You do not need to specify a serviceAccount
+    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
+    #serviceAccount: hpe-sampletenant
+  executor:
+    cores: 1
+    coreLimit: "1000m"
+    instances: 2
+    memory: "512m"
+    labels:
+      version: 2.4.7

--- a/examples/ecp-5.3.0/2.4.7/advancedsamples/spark-solr-kerberos.yaml
+++ b/examples/ecp-5.3.0/2.4.7/advancedsamples/spark-solr-kerberos.yaml
@@ -1,0 +1,115 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#########################################################################################################
+# This is an example of spark app configuration that is able to work with kerberised solr and zookeeper #
+# All config files and keytab are mounted here using configMaps and secrets, but this is not the only   #
+# way to add these files to container.                                                                  #
+#########################################################################################################
+#
+# To run this configuration, the following files are required:
+# - jaas config
+# - kerberos config
+# - user keytab
+#
+# All these files should be present in both driver and executor pods.
+# For example, create configmaps for conf files and put keytab into a secret:
+# kubectl create cm solr-jaas-client-conf -n [tenant-ns] --from-file /path/to/jaas.conf
+# kubectl create cm kerberos-conf -n [tenant-ns] --from-file /path/to/krb5.conf
+# kubectl create secret generic solr-keytab -n [tenant-ns] --from-file /path/to/user.keytab
+#
+# Then mount values from these maps and secret as shown in this example below.
+#
+# To configure spark to use there files, make sure to:
+# - specify path to krb5.conf file via "java.security.krb5.conf" property
+# - specify name of jaas configuration via "solr.kerberos.jaas.appname" property
+# - specify path to jaas.conf file via env variable "SOLR_JAAS_CONF"
+# These changes should be applied to both driver and executor specs.
+#
+# Spark image contains a prebuilt spark-solr connector that must be used. It's included to classpath via deps.jars.
+#
+# Important: avoid using default name of jaas config like 'Client'. It will lead to spark app failure.
+# Use recognizable name like "SolrApp"
+#
+
+
+apiVersion: "sparkoperator.hpe.com/v1beta2"
+kind: SparkApplication
+metadata:
+  name: solr-demo
+  namespace: sampletenant
+spec:
+  sparkConf:
+  #    spark.mapr.user.secret: mapr-secret
+  #    spark.eventLog.enabled: "false"
+  #    spark.eventLog.dir: "maprfs:///apps/spark/sampletenant"
+
+  type: Scala
+  sparkVersion: 2.4.7
+  mode: cluster
+  image: gcr.io/mapr-252711/spark-2.4.7:202104010902C
+  imagePullPolicy: Always
+  mainApplicationFile: maprfs:///path/to/application.jar
+  mainClass: your.main.Class
+  restartPolicy:
+    type: Never
+  imagePullSecrets:
+    - imagepull
+  deps:
+    jars:
+      - "local:///opt/mapr/spark/spark-2.4.7/external_jars/spark-solr-3.9.0_2.12.jar"
+  driver:
+    cores: 1
+    coreLimit: "1000m"
+    memory: "512m"
+    labels:
+      version: 2.4.7
+#      serviceAccount: hpe-sampletenant
+    # Driver SOLR+KERBEROS-specific options
+    javaOptions: "-Dsolr.kerberos.jaas.appname=[config-name-from-jaas.conf] -Djava.security.krb5.conf=[path-to-mounted-kerberos-config]"
+    env:
+      - name: SOLR_JAAS_CONF
+        value: "[path-to-mounted-jaas-config]"
+    secrets:
+      - name: solr-keytab
+        path: /keytabs
+        secretType: Generic
+    configMaps:
+      - name: solr-jaas-client-conf
+        path: /mnt/solr
+      - name: kerberos-conf
+        path: /mnt/kerberos
+  executor:
+    instances: 2
+    cores: 1
+    coreLimit: "1000m"
+    memory: "512m"
+    labels:
+      version: 2.4.7
+    # Executor SOLR+KERBEROS-specific options
+    env:
+      - name: SOLR_JAAS_CONF
+        value: "[path-to-mounted-jaas-config]"
+    javaOptions: "-Dsolr.kerberos.jaas.appname=[config-name-from-jaas.conf] -Djava.security.krb5.conf=[path-to-mounted-kerberos-config]"
+    secrets:
+      - name: solr-keytab
+        path: /keytabs
+        secretType: Generic
+    configMaps:
+      - name: solr-jaas-client-conf
+        path: /mnt/solr
+      - name: kerberos-conf
+        path: /mnt/kerberos

--- a/examples/ecp-5.3.0/2.4.7/pyspark-wc.yaml
+++ b/examples/ecp-5.3.0/2.4.7/pyspark-wc.yaml
@@ -1,0 +1,58 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "sparkoperator.hpe.com/v1beta2"
+kind: SparkApplication
+metadata:
+  name: pyspark-wordcount-secure
+  namespace: sampletenant
+spec:
+  #sparkConf:
+    # Note: If you are executing the application as a K8 user that MapR can verify,
+    #       you do not need to specify a spark.mapr.user.secret
+    #spark.mapr.user.secret: spark-user-secret
+    # Note: You do not need to specify a spark.eventLog.dir
+    #       it will be auto-generated with the pattern "maprfs:///apps/spark/<namespace>"
+    #spark.eventLog.dir: "maprfs:///apps/spark/sampletenant"
+  type: Python
+  sparkVersion: 2.4.7
+  pythonVersion: "3"
+  mode: cluster
+  image: gcr.io/mapr-252711/spark-py-2.4.7:202104010902C
+  imagePullPolicy: Always
+  mainApplicationFile: local:///opt/mapr/spark/spark-2.4.7/examples/src/main/python/wordcount.py
+  restartPolicy:
+    type: Never
+  arguments:
+  - maprfs:///tmp/input.txt
+  imagePullSecrets:
+  - imagepull
+  driver:
+    cores: 1
+    coreLimit: "1000m"
+    memory: "512m"
+    labels:
+      version: 2.4.7
+    # Note: You do not need to specify a serviceAccount
+    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
+    #serviceAccount: hpe-sampletenant
+  executor:
+    cores: 1
+    coreLimit: "1000m"
+    instances: 2
+    memory: "512m"
+    labels:
+      version: 2.4.7

--- a/examples/ecp-5.3.0/2.4.7/r-spark-naive-bayes.yaml
+++ b/examples/ecp-5.3.0/2.4.7/r-spark-naive-bayes.yaml
@@ -1,0 +1,55 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "sparkoperator.hpe.com/v1beta2"
+kind: SparkApplication
+metadata:
+  name: sparkr-naive-bayes-secure
+  namespace: sampletenant
+spec:
+  #sparkConf:
+    # Note: If you are executing the application as a K8 user that MapR can verify,
+    #       you do not need to specify a spark.mapr.user.secret
+    #spark.mapr.user.secret: spark-user-secret
+    # Note: You do not need to specify a spark.eventLog.dir
+    #       it will be auto-generated with the pattern "maprfs:///apps/spark/<namespace>"
+    #spark.eventLog.dir: "maprfs:///apps/spark/sampletenant"
+  type: R
+  sparkVersion: 2.4.7
+  mode: cluster
+  image: gcr.io/mapr-252711/spark-r-2.4.7:202104010902C
+  imagePullPolicy: Always
+  mainApplicationFile: local:///opt/mapr/spark/spark-2.4.7/examples/src/main/r/ml/naiveBayes.R
+  restartPolicy:
+    type: Never
+  imagePullSecrets:
+  - imagepull
+  driver:
+    cores: 1
+    coreLimit: "1000m"
+    memory: "512m"
+    labels:
+      version: 2.4.7
+    # Note: You do not need to specify a serviceAccount
+    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
+    #serviceAccount: hpe-sampletenant
+  executor:
+    cores: 1
+    coreLimit: "1000m"
+    instances: 2
+    memory: "512m"
+    labels:
+      version: 2.4.7

--- a/examples/ecp-5.3.0/2.4.7/spark-hive.yaml
+++ b/examples/ecp-5.3.0/2.4.7/spark-hive.yaml
@@ -1,0 +1,64 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "sparkoperator.hpe.com/v1beta2"
+kind: SparkApplication
+metadata:
+  name: spark-hive-secure
+  namespace: sampletenant
+spec:
+  #sparkConf:
+    # Note: If you are executing the application as a K8 user that MapR can verify,
+    #       you do not need to specify a spark.mapr.user.secret
+    #spark.mapr.user.secret: spark-user-secret
+    # Note: You do not need to specify a spark.eventLog.dir
+    #       it will be auto-generated with the pattern "maprfs:///apps/spark/<namespace>"
+    #spark.eventLog.dir: "maprfs:///apps/spark/sampletenant"
+  type: Scala
+  sparkVersion: 2.4.7
+  mode: cluster
+  image: gcr.io/mapr-252711/spark-2.4.7:202104010902C
+  imagePullPolicy: Always
+  mainClass: org.apache.spark.examples.sql.hive.SparkHiveExample
+  mainApplicationFile: "local:///opt/mapr/spark/spark-2.4.7/examples/jars/spark-examples_2.12-2.4.7.2-mapr-701.jar"
+  restartPolicy:
+    type: Never
+  imagePullSecrets:
+  - imagepull
+  driver:
+    cores: 1
+    coreLimit: "1000m"
+    memory: "512m"
+    labels:
+      version: 2.4.7
+    volumeMounts:
+    - name: hive-site-volume
+      mountPath: /opt/mapr/spark/spark-2.4.7/conf/hive-site.xml
+      subPath: hive-site.xml
+  executor:
+    cores: 1
+    coreLimit: "1000m"
+    instances: 2
+    memory: "512m"
+    labels:
+      version: 2.4.7
+    # Note: You do not need to specify a serviceAccount
+    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
+    #serviceAccount: hpe-sampletenant
+  volumes:
+  - name: hive-site-volume
+    configMap:
+      name: hivesite-cm

--- a/examples/ecp-5.3.0/2.4.7/spark-pi-scheduled.yaml
+++ b/examples/ecp-5.3.0/2.4.7/spark-pi-scheduled.yaml
@@ -1,0 +1,43 @@
+apiVersion: "sparkoperator.hpe.com/v1beta2"
+kind: ScheduledSparkApplication
+metadata:
+  name: spark-pi-scheduled
+  namespace: sampletenant
+spec:
+  schedule: "@every 1m"
+  concurrencyPolicy: Allow
+  template:
+    #sparkConf:
+      # Note: If you are executing the application as a K8 user that MapR can verify,
+      #       you do not need to specify a spark.mapr.user.secret
+      #spark.mapr.user.secret: spark-user-secret
+      # Note: You do not need to specify a spark.eventLog.dir
+      #       it will be auto-generated with the pattern "maprfs:///apps/spark/<namespace>"
+      #spark.eventLog.dir: "maprfs:///apps/spark/sampletenant"
+    type: Scala
+    sparkVersion: 2.4.7
+    mode: cluster
+    image: gcr.io/mapr-252711/spark-2.4.7:202104010902C
+    imagePullPolicy: Always
+    imagePullSecrets:
+      - imagepull
+    mainClass: org.apache.spark.examples.SparkPi
+    mainApplicationFile: "local:///opt/mapr/spark/spark-2.4.7/examples/jars/spark-examples_2.12-2.4.7.2-mapr-701.jar"
+    restartPolicy:
+      type: Never
+    driver:
+      cores: 1
+      coreLimit: "1000m"
+      memory: "512m"
+      labels:
+        version: 2.4.7
+      # Note: You do not need to specify a serviceAccount
+      #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
+      #serviceAccount: hpe-sampletenant
+    executor:
+      cores: 1
+      coreLimit: "1000m"
+      instances: 1
+      memory: "512m"
+      labels:
+        version: 2.4.7

--- a/examples/ecp-5.3.0/2.4.7/spark-pi.yaml
+++ b/examples/ecp-5.3.0/2.4.7/spark-pi.yaml
@@ -1,0 +1,56 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "sparkoperator.hpe.com/v1beta2"
+kind: SparkApplication
+metadata:
+  name: spark-pi-secure
+  namespace: sampletenant
+spec:
+  #sparkConf:
+    # Note: If you are executing the application as a K8 user that MapR can verify,
+    #       you do not need to specify a spark.mapr.user.secret
+    #spark.mapr.user.secret: spark-user-secret
+    # Note: You do not need to specify a spark.eventLog.dir
+    #       it will be auto-generated with the pattern "maprfs:///apps/spark/<namespace>"
+    #spark.eventLog.dir: "maprfs:///apps/spark/sampletenant"
+  type: Scala
+  sparkVersion: 2.4.7
+  mode: cluster
+  image: gcr.io/mapr-252711/spark-2.4.7:202104010902C
+  imagePullPolicy: Always
+  imagePullSecrets:
+  - imagepull
+  mainClass: org.apache.spark.examples.SparkPi
+  mainApplicationFile: "local:///opt/mapr/spark/spark-2.4.7/examples/jars/spark-examples_2.12-2.4.7.2-mapr-701.jar"
+  restartPolicy:
+    type: Never
+  driver:
+    cores: 1
+    coreLimit: "1000m"
+    memory: "512m"
+    labels:
+      version: 2.4.7
+    # Note: You do not need to specify a serviceAccount
+    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
+    #serviceAccount: hpe-sampletenant
+  executor:
+    cores: 1
+    coreLimit: "1000m"
+    instances: 1
+    memory: "512m"
+    labels:
+      version: 2.4.7

--- a/examples/ecp-5.3.0/2.4.7/spark-streaming-queue.yaml
+++ b/examples/ecp-5.3.0/2.4.7/spark-streaming-queue.yaml
@@ -1,0 +1,56 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "sparkoperator.hpe.com/v1beta2"
+kind: SparkApplication
+metadata:
+  name: spark-streaming-queue-secure
+  namespace: sampletenant
+spec:
+  #sparkConf:
+    # Note: If you are executing the application as a K8 user that MapR can verify,
+    #       you do not need to specify a spark.mapr.user.secret
+    #spark.mapr.user.secret: spark-user-secret
+    # Note: You do not need to specify a spark.eventLog.dir
+    #       it will be auto-generated with the pattern "maprfs:///apps/spark/<namespace>"
+    #spark.eventLog.dir: "maprfs:///apps/spark/sampletenant"
+  type: Scala
+  sparkVersion: 2.4.7
+  mode: cluster
+  image: gcr.io/mapr-252711/spark-2.4.7:202104010902C
+  imagePullPolicy: Always
+  mainClass: org.apache.spark.examples.streaming.QueueStream
+  mainApplicationFile: "local:///opt/mapr/spark/spark-2.4.7/examples/jars/spark-examples_2.12-2.4.7.2-mapr-701.jar"
+  restartPolicy:
+    type: Never
+  imagePullSecrets:
+  - imagepull
+  driver:
+    cores: 1
+    coreLimit: "1000m"
+    memory: "512m"
+    labels:
+      version: 2.4.7
+    # Note: You do not need to specify a serviceAccount
+    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
+    #serviceAccount: hpe-sampletenant
+  executor:
+    cores: 1
+    coreLimit: "1000m"
+    instances: 2
+    memory: "512m"
+    labels:
+      version: 2.4.7

--- a/examples/ecp-5.3.0/2.4.7/spark-wc.yaml
+++ b/examples/ecp-5.3.0/2.4.7/spark-wc.yaml
@@ -1,0 +1,58 @@
+#
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "sparkoperator.hpe.com/v1beta2"
+kind: SparkApplication
+metadata:
+  name: spark-wordcount-secure
+  namespace: sampletenant
+spec:
+  #sparkConf:
+    # Note: If you are executing the application as a K8 user that MapR can verify,
+    #       you do not need to specify a spark.mapr.user.secret
+    #spark.mapr.user.secret: spark-user-secret
+    # Note: You do not need to specify a spark.eventLog.dir
+    #       it will be auto-generated with the pattern "maprfs:///apps/spark/<namespace>"
+    #spark.eventLog.dir: "maprfs:///apps/spark/sampletenant"
+  type: Java
+  sparkVersion: 2.4.7
+  mode: cluster
+  image: gcr.io/mapr-252711/spark-2.4.7:202104010902C
+  imagePullPolicy: Always
+  mainClass: org.apache.spark.examples.JavaWordCount
+  mainApplicationFile: "local:///opt/mapr/spark/spark-2.4.7/examples/jars/spark-examples_2.12-2.4.7.2-mapr-701.jar"
+  restartPolicy:
+    type: Never
+  arguments:
+  - maprfs:///tmp/input.txt
+  imagePullSecrets:
+  - imagepull
+  driver:
+    cores: 1
+    coreLimit: "1000m"
+    memory: "512m"
+    labels:
+      version: 2.4.7
+    # Note: You do not need to specify a serviceAccount
+    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
+    #serviceAccount: hpe-sampletenant
+  executor:
+    cores: 1
+    coreLimit: "1000m"
+    instances: 2
+    memory: "512m"
+    labels:
+      version: 2.4.7

--- a/examples/ecp-5.3.0/3.1.1/spark-pi-configmap.yaml
+++ b/examples/ecp-5.3.0/3.1.1/spark-pi-configmap.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Google LLC
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,41 +12,43 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Support for Python is experimental, and requires building SNAPSHOT image of Apache Spark,
-# with `imagePullPolicy` set to Always
 
 apiVersion: "sparkoperator.k8s.io/v1beta2"
 kind: SparkApplication
 metadata:
-  name: pyspark-pi
+  name: spark-pi
   namespace: default
 spec:
-  type: Python
-  pythonVersion: "3"
+  type: Scala
   mode: cluster
-  image: "gcr.io/mapr-252711/apache-spark-py-3.1.1:latest"
+  image: "gcr.io/mapr-252711/apache-spark-3.1.1:latest"
   imagePullPolicy: Always
-  imagePullSecrets:
-    - imagepull
-  mainApplicationFile: local:///opt/spark/examples/src/main/python/pi.py
+  mainClass: org.apache.spark.examples.SparkPi
+  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.1.1.jar"
   sparkVersion: "3.1.1"
   restartPolicy:
-    type: OnFailure
-    onFailureRetries: 3
-    onFailureRetryInterval: 10
-    onSubmissionFailureRetries: 5
-    onSubmissionFailureRetryInterval: 20
+    type: Never
+  volumes:
+    - name: config-vol
+      configMap:
+        name: dummy-cm
   driver:
     cores: 1
     coreLimit: "1200m"
     memory: "512m"
     labels:
-      version: 3.0.0
+      version: 3.1.1
+    # Note: If you run app in tenant namespace - change serviceAccount name to "hpe-<namespace>"
     serviceAccount: spark
+    volumeMounts:
+      - name: config-vol
+        mountPath: /opt/spark/mycm
   executor:
     cores: 1
     instances: 1
     memory: "512m"
     labels:
-      version: 3.0.0
+      version: 3.1.1
+    volumeMounts:
+      - name: config-vol
+        mountPath: /opt/spark/mycm

--- a/examples/ecp-5.3.0/3.1.1/spark-pi-custom-resource.yaml
+++ b/examples/ecp-5.3.0/3.1.1/spark-pi-custom-resource.yaml
@@ -16,18 +16,16 @@
 apiVersion: "sparkoperator.k8s.io/v1beta2"
 kind: SparkApplication
 metadata:
-  name: spark-pi
+  name: spark-pi-custom-resource
   namespace: default
 spec:
   type: Scala
   mode: cluster
   image: "gcr.io/mapr-252711/apache-spark-3.1.1:latest"
   imagePullPolicy: Always
-  imagePullSecrets:
-    - imagepull
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.1.1.jar"
-  sparkVersion: "3.1.1"
+  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.5.jar"
+  sparkVersion: "2.4.5"
   restartPolicy:
     type: Never
   volumes:
@@ -40,7 +38,8 @@ spec:
     coreLimit: "1200m"
     memory: "512m"
     labels:
-      version: 3.1.1
+      version: 2.4.5
+    # Note: If you run app in tenant namespace - change serviceAccount name to "hpe-<namespace>"
     serviceAccount: spark
     volumeMounts:
       - name: "test-volume"
@@ -50,7 +49,11 @@ spec:
     instances: 1
     memory: "512m"
     labels:
-      version: 3.1.1
+      version: 2.4.5
     volumeMounts:
       - name: "test-volume"
         mountPath: "/tmp"
+  batchSchedulerOptions:
+    resources:
+        cpu: "2"
+        memory: "4096m"

--- a/examples/ecp-5.3.0/3.1.1/spark-pi-schedule.yaml
+++ b/examples/ecp-5.3.0/3.1.1/spark-pi-schedule.yaml
@@ -38,6 +38,7 @@ spec:
       memory: "512m"
       labels:
         version: 3.1.1
+      # Note: If you run app in tenant namespace - change serviceAccount name to "hpe-<namespace>"
       serviceAccount: spark
     executor:
       cores: 1

--- a/examples/ecp-5.3.0/3.1.1/spark-pi.yaml
+++ b/examples/ecp-5.3.0/3.1.1/spark-pi.yaml
@@ -23,25 +23,29 @@ spec:
   mode: cluster
   image: "gcr.io/mapr-252711/apache-spark-3.1.1:latest"
   imagePullPolicy: Always
+  imagePullSecrets:
+    - imagepull
   mainClass: org.apache.spark.examples.SparkPi
   mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.1.1.jar"
   sparkVersion: "3.1.1"
   restartPolicy:
     type: Never
   volumes:
-    - name: config-vol
-      configMap:
-        name: dummy-cm
+    - name: "test-volume"
+      hostPath:
+        path: "/tmp"
+        type: Directory
   driver:
     cores: 1
     coreLimit: "1200m"
     memory: "512m"
     labels:
       version: 3.1.1
+    # Note: If you run app in tenant namespace - change serviceAccount name to "hpe-<namespace>"
     serviceAccount: spark
     volumeMounts:
-      - name: config-vol
-        mountPath: /opt/spark/mycm
+      - name: "test-volume"
+        mountPath: "/tmp"
   executor:
     cores: 1
     instances: 1
@@ -49,5 +53,5 @@ spec:
     labels:
       version: 3.1.1
     volumeMounts:
-      - name: config-vol
-        mountPath: /opt/spark/mycm
+      - name: "test-volume"
+        mountPath: "/tmp"

--- a/examples/ecp-5.3.0/3.1.1/spark-py-pi.yaml
+++ b/examples/ecp-5.3.0/3.1.1/spark-py-pi.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,47 +12,42 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Support for Python is experimental, and requires building SNAPSHOT image of Apache Spark,
+# with `imagePullPolicy` set to Always
 
 apiVersion: "sparkoperator.k8s.io/v1beta2"
 kind: SparkApplication
 metadata:
-  name: spark-pi-custom-resource
+  name: pyspark-pi
   namespace: default
 spec:
-  type: Scala
+  type: Python
+  pythonVersion: "3"
   mode: cluster
-  image: "gcr.io/mapr-252711/apache-spark-3.1.1:latest"
+  image: "gcr.io/mapr-252711/apache-spark-py-3.1.1:latest"
   imagePullPolicy: Always
-  mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.5.jar"
-  sparkVersion: "2.4.5"
+  imagePullSecrets:
+    - imagepull
+  mainApplicationFile: local:///opt/spark/examples/src/main/python/pi.py
+  sparkVersion: "3.1.1"
   restartPolicy:
-    type: Never
-  volumes:
-    - name: "test-volume"
-      hostPath:
-        path: "/tmp"
-        type: Directory
+    type: OnFailure
+    onFailureRetries: 3
+    onFailureRetryInterval: 10
+    onSubmissionFailureRetries: 5
+    onSubmissionFailureRetryInterval: 20
   driver:
     cores: 1
     coreLimit: "1200m"
     memory: "512m"
     labels:
-      version: 2.4.5
+      version: 3.1.1
+    # Note: If you run app in tenant namespace - change serviceAccount name to "hpe-<namespace>"
     serviceAccount: spark
-    volumeMounts:
-      - name: "test-volume"
-        mountPath: "/tmp"
   executor:
     cores: 1
     instances: 1
     memory: "512m"
     labels:
-      version: 2.4.5
-    volumeMounts:
-      - name: "test-volume"
-        mountPath: "/tmp"
-  batchSchedulerOptions:
-    resources:
-        cpu: "2"
-        memory: "4096m"
+      version: 3.1.1


### PR DESCRIPTION
- add examples for hpe spark operator v2.4.4 and v2.4.7
- move apache spark examples