### PR TITLE
Add option to add owner references to helm charts

### DIFF
--- a/charts/livy-0.8.0/livy-chart/templates/configmap.yaml
+++ b/charts/livy-0.8.0/livy-chart/templates/configmap.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "livy.fullname" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "livy.labels" . | nindent 4 }}
 data:

--- a/charts/livy-0.8.0/livy-chart/templates/imagepull.yaml
+++ b/charts/livy-0.8.0/livy-chart/templates/imagepull.yaml
@@ -3,6 +3,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.defaultPullSecret }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ .Files.Get "files/example-imagepullsecret" | b64enc }}

--- a/charts/livy-0.8.0/livy-chart/templates/rbac.yaml
+++ b/charts/livy-0.8.0/livy-chart/templates/rbac.yaml
@@ -4,6 +4,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "livy.fullname" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "livy.labels" . | nindent 4 }}
 rules:
@@ -30,6 +35,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "livy.fullname" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "livy.labels" . | nindent 4 }}
 roleRef:

--- a/charts/livy-0.8.0/livy-chart/templates/service.yaml
+++ b/charts/livy-0.8.0/livy-chart/templates/service.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "livy.fullname" . }}-http
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "livy.labels" . | nindent 4 }}
 spec:

--- a/charts/livy-0.8.0/livy-chart/templates/serviceaccount.yaml
+++ b/charts/livy-0.8.0/livy-chart/templates/serviceaccount.yaml
@@ -3,6 +3,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "livy.serviceAccountName" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "livy.labels" . | nindent 4 }}
   {{- with .Values.serviceAccounts.livy.annotations }}

--- a/charts/livy-0.8.0/livy-chart/templates/spark-rbac.yaml
+++ b/charts/livy-0.8.0/livy-chart/templates/spark-rbac.yaml
@@ -4,6 +4,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "livy.fullname" . }}-spark
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "livy.labels" . | nindent 4 }}
 rules:
@@ -23,6 +28,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "livy.fullname" . }}-spark
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "livy.labels" . | nindent 4 }}
 roleRef:

--- a/charts/livy-0.8.0/livy-chart/templates/spark-serviceaccount.yaml
+++ b/charts/livy-0.8.0/livy-chart/templates/spark-serviceaccount.yaml
@@ -3,6 +3,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "livy.sparkServiceAccountName" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "livy.labels" . | nindent 4 }}
   {{- with .Values.serviceAccounts.spark.annotations }}

--- a/charts/livy-0.8.0/livy-chart/templates/statefulset.yaml
+++ b/charts/livy-0.8.0/livy-chart/templates/statefulset.yaml
@@ -2,6 +2,11 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "livy.fullname" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "livy.labels" . | nindent 4 }}
 spec:

--- a/charts/livy-0.8.0/livy-chart/values.yaml
+++ b/charts/livy-0.8.0/livy-chart/values.yaml
@@ -24,6 +24,10 @@ serviceAccounts:
     annotations: {}
     name: ""
 
+ownerReference:
+  overRide: false
+  ownerReferences: {}
+
 rbac:
   create: true
 

--- a/charts/metastore-2.3.8/metastore-chart/templates/configmap.yaml
+++ b/charts/metastore-2.3.8/metastore-chart/templates/configmap.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "metastore.fullname" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "metastore.labels" . | nindent 4 }}
 data:

--- a/charts/metastore-2.3.8/metastore-chart/templates/imagepull.yaml
+++ b/charts/metastore-2.3.8/metastore-chart/templates/imagepull.yaml
@@ -3,6 +3,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.defaultPullSecret }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ .Files.Get "files/example-imagepullsecret" | b64enc }}

--- a/charts/metastore-2.3.8/metastore-chart/templates/rbac.yaml
+++ b/charts/metastore-2.3.8/metastore-chart/templates/rbac.yaml
@@ -4,6 +4,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "metastore.fullname" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
   {{- include "metastore.labels" . | nindent 4 }}
 rules:
@@ -23,6 +28,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "metastore.fullname" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
   {{- include "metastore.labels" . | nindent 4 }}
 roleRef:

--- a/charts/metastore-2.3.8/metastore-chart/templates/service-external.yaml
+++ b/charts/metastore-2.3.8/metastore-chart/templates/service-external.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{.Values.externalService.name }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
   {{- include "metastore.labels" . | nindent 4 }}
 spec:

--- a/charts/metastore-2.3.8/metastore-chart/templates/service.yaml
+++ b/charts/metastore-2.3.8/metastore-chart/templates/service.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.service.name }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "metastore.labels" . | nindent 4 }}
 spec:

--- a/charts/metastore-2.3.8/metastore-chart/templates/serviceaccount.yaml
+++ b/charts/metastore-2.3.8/metastore-chart/templates/serviceaccount.yaml
@@ -3,6 +3,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "metastore.serviceAccountName" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "metastore.labels" . | nindent 4 }}
   {{- with .Values.serviceAccounts.metastore.annotations }}

--- a/charts/metastore-2.3.8/metastore-chart/templates/spark-rbac.yaml
+++ b/charts/metastore-2.3.8/metastore-chart/templates/spark-rbac.yaml
@@ -4,6 +4,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "metastore.fullname" . }}-spark
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
   {{- include "metastore.labels" . | nindent 4 }}
 rules:

--- a/charts/metastore-2.3.8/metastore-chart/templates/spark-serviceaccount.yaml
+++ b/charts/metastore-2.3.8/metastore-chart/templates/spark-serviceaccount.yaml
@@ -3,6 +3,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "metastore.sparkServiceAccountName" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
   {{- include "metastore.labels" . | nindent 4 }}
   {{- with .Values.serviceAccounts.spark.annotations }}

--- a/charts/metastore-2.3.8/metastore-chart/templates/statefulSet.yaml
+++ b/charts/metastore-2.3.8/metastore-chart/templates/statefulSet.yaml
@@ -2,6 +2,11 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "metastore.fullname" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "metastore.labels" . | nindent 4 }}
 spec:

--- a/charts/metastore-2.3.8/metastore-chart/values.yaml
+++ b/charts/metastore-2.3.8/metastore-chart/values.yaml
@@ -27,6 +27,10 @@ serviceAccounts:
     annotations: {}
     name: ""
 
+ownerReference:
+  overRide: false
+  ownerReferences: {}
+
 rbac:
   create: true
 

--- a/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/clusterrole.yaml
+++ b/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/clusterrole.yaml
@@ -3,6 +3,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: '{{ template "mysql-operator.fullname" . }}'
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     app: '{{ template "mysql-operator.name" . }}'
     chart: '{{ template "mysql-operator.chart" . }}'

--- a/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/clusterrolebinding.yaml
+++ b/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/clusterrolebinding.yaml
@@ -3,6 +3,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "mysql-operator.fullname" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     app: {{ template "mysql-operator.name" . }}
     chart: {{ template "mysql-operator.chart" . }}

--- a/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/orc-config.yaml
+++ b/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/orc-config.yaml
@@ -20,6 +20,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "mysql-operator.orc-config-name" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     app: {{ template "mysql-operator.name" . }}
     chart: {{ template "mysql-operator.chart" . }}

--- a/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/orc-ingress.yaml
+++ b/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/orc-ingress.yaml
@@ -4,6 +4,11 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "mysql-operator.labels" . | nindent 4 }}
   {{- with .Values.orchestrator.ingress.annotations }}

--- a/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/orc-secret.yaml
+++ b/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/orc-secret.yaml
@@ -3,6 +3,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "mysql-operator.orc-secret-name" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     app: {{ template "mysql-operator.name" . }}
     chart: {{ template "mysql-operator.chart" . }}

--- a/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/orc-service.yaml
+++ b/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/orc-service.yaml
@@ -10,6 +10,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $fullName }}-{{ $i }}-svc
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     app: {{ $fullName }}
     chart: {{ $chart }}

--- a/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/pdb.yaml
+++ b/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/pdb.yaml
@@ -3,6 +3,11 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "mysql-operator.fullname" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     app: {{ template "mysql-operator.name" . }}
     chart: {{ template "mysql-operator.chart" . }}

--- a/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/podsecuritypolicy.yaml
+++ b/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/podsecuritypolicy.yaml
@@ -3,6 +3,11 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: '{{ template "mysql-operator.fullname" . }}'
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     app: '{{ template "mysql-operator.name" . }}'
     chart: '{{ template "mysql-operator.chart" . }}'

--- a/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/role.yaml
+++ b/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/role.yaml
@@ -3,6 +3,11 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: '{{ template "mysql-operator.fullname" . }}'
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     app: '{{ template "mysql-operator.name" . }}'
     chart: '{{ template "mysql-operator.chart" . }}'

--- a/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/rolebinding.yaml
+++ b/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/rolebinding.yaml
@@ -3,6 +3,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: '{{ template "mysql-operator.fullname" . }}'
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     app: '{{ template "mysql-operator.name" . }}'
     chart: '{{ template "mysql-operator.chart" . }}'

--- a/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/serviceaccount.yaml
+++ b/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/serviceaccount.yaml
@@ -3,6 +3,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "mysql-operator.serviceAccountName" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     app: {{ template "mysql-operator.name" . }}
     chart: {{ template "mysql-operator.chart" . }}

--- a/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/servicemonitor.yaml
+++ b/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/servicemonitor.yaml
@@ -5,6 +5,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "mysql-operator.fullname" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "mysql-operator.labels" . | nindent 4 }}
     {{- if .Values.serviceMonitor.additionalLabels }}

--- a/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/statefulset.yaml
+++ b/charts/mysql-operator-v0.1.5/mysql-operator-chart/templates/statefulset.yaml
@@ -2,6 +2,11 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "mysql-operator.fullname" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     app: {{ template "mysql-operator.name" . }}
     chart: {{ template "mysql-operator.chart" . }}

--- a/charts/mysql-operator-v0.1.5/mysql-operator-chart/values.yaml
+++ b/charts/mysql-operator-v0.1.5/mysql-operator-chart/values.yaml
@@ -83,6 +83,10 @@ rbac:
   # if rbac is false this service account is used
   serviceAccountName: default
 
+ownerReference:
+  overRide: false
+  ownerReferences: {}
+
 orchestrator:
   image: quay.io/presslabs/mysql-operator-orchestrator:latest
 

--- a/charts/spark-2.4.7/spark-operator-chart/templates/imagepull.yaml
+++ b/charts/spark-2.4.7/spark-operator-chart/templates/imagepull.yaml
@@ -4,6 +4,11 @@ kind: Secret
 metadata:
   name: {{ .Values.defaultPullSecret }}
   namespace: {{ include "spark-operator.sparknamespace" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ .Files.Get "files/example-imagepullsecret" | b64enc }}

--- a/charts/spark-2.4.7/spark-operator-chart/templates/spark-cr.yaml
+++ b/charts/spark-2.4.7/spark-operator-chart/templates/spark-cr.yaml
@@ -2,6 +2,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "spark-operator.clusterrole" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
 rules:
 - apiGroups: [""]
   resources: ["pods"]

--- a/charts/spark-2.4.7/spark-operator-chart/templates/spark-crb.yaml
+++ b/charts/spark-2.4.7/spark-operator-chart/templates/spark-crb.yaml
@@ -2,6 +2,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "spark-operator.clusterrolebinding" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}

--- a/charts/spark-2.4.7/spark-operator-chart/templates/spark-deploy-sparkoperator.yaml
+++ b/charts/spark-2.4.7/spark-operator-chart/templates/spark-deploy-sparkoperator.yaml
@@ -3,6 +3,11 @@ kind: Deployment
 metadata:
   name: {{ include "spark-operator.name" . }}
   namespace: {{ include "spark-operator.sparknamespace" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
 spec:

--- a/charts/spark-2.4.7/spark-operator-chart/templates/spark-job-sparkoperator.yaml
+++ b/charts/spark-2.4.7/spark-operator-chart/templates/spark-job-sparkoperator.yaml
@@ -3,6 +3,11 @@ kind: Job
 metadata:
   name: {{ include "spark-operator.webhookinit" . }}
   namespace: {{ include "spark-operator.sparknamespace" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
   {{- include "spark-operator.labels" . | nindent 4 }}
 spec:

--- a/charts/spark-2.4.7/spark-operator-chart/templates/spark-namespace.yaml
+++ b/charts/spark-2.4.7/spark-operator-chart/templates/spark-namespace.yaml
@@ -3,4 +3,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ include "spark-operator.sparknamespace" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
 {{- end -}}

--- a/charts/spark-2.4.7/spark-operator-chart/templates/spark-sa.yaml
+++ b/charts/spark-2.4.7/spark-operator-chart/templates/spark-sa.yaml
@@ -4,4 +4,9 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
   namespace: {{ include "spark-operator.sparknamespace" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/spark-2.4.7/spark-operator-chart/templates/spark-svc-sparkoperator.yaml
+++ b/charts/spark-2.4.7/spark-operator-chart/templates/spark-svc-sparkoperator.yaml
@@ -3,6 +3,11 @@ apiVersion: v1
 metadata:
   name: {{ .Values.webhook.name }}
   namespace: {{ include "spark-operator.sparknamespace" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
 spec:
   ports:
   - port: {{ .Values.webhook.port }}

--- a/charts/spark-2.4.7/spark-operator-chart/values.yaml
+++ b/charts/spark-2.4.7/spark-operator-chart/values.yaml
@@ -29,6 +29,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: "hpe-sparkoperator"
 
+ownerReference:
+  overRide: false
+  ownerReferences: {}
+
 webhook:
   # -- name for webhook service
   name: spark-webhook

--- a/charts/spark-3.1.1/spark-operator-chart/templates/deployment.yaml
+++ b/charts/spark-3.1.1/spark-operator-chart/templates/deployment.yaml
@@ -8,6 +8,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "spark-operator.fullname" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
 spec:

--- a/charts/spark-3.1.1/spark-operator-chart/templates/imagepull.yaml
+++ b/charts/spark-3.1.1/spark-operator-chart/templates/imagepull.yaml
@@ -4,6 +4,11 @@ kind: Secret
 metadata:
   name: {{ .Values.defaultPullSecret }}
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ .Files.Get "files/example-imagepullsecret" | b64enc }}
@@ -16,6 +21,11 @@ kind: Secret
 metadata:
   name: {{ .Values.defaultPullSecret }}
   namespace: {{ .Values.sparkJobNamespace }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ .Files.Get "files/example-imagepullsecret" | b64enc }}

--- a/charts/spark-3.1.1/spark-operator-chart/templates/prometheus-podmonitor.yaml
+++ b/charts/spark-3.1.1/spark-operator-chart/templates/prometheus-podmonitor.yaml
@@ -3,6 +3,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ include "spark-operator.name" . -}}-podmonitor
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels: {{ toYaml .Values.podMonitor.labels | nindent 4 }}
 spec:
   podMetricsEndpoints:

--- a/charts/spark-3.1.1/spark-operator-chart/templates/rbac.yaml
+++ b/charts/spark-3.1.1/spark-operator-chart/templates/rbac.yaml
@@ -3,6 +3,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "spark-operator.fullname" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
 rules:

--- a/charts/spark-3.1.1/spark-operator-chart/templates/serviceaccount.yaml
+++ b/charts/spark-3.1.1/spark-operator-chart/templates/serviceaccount.yaml
@@ -3,6 +3,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "spark-operator.serviceAccountName" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   annotations:
     "helm.sh/hook": pre-install
   labels:

--- a/charts/spark-3.1.1/spark-operator-chart/templates/spark-rbac.yaml
+++ b/charts/spark-3.1.1/spark-operator-chart/templates/spark-rbac.yaml
@@ -4,6 +4,11 @@ kind: Role
 metadata:
   name: spark-role
   namespace: {{ default .Release.Namespace .Values.sparkJobNamespace }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
 rules:

--- a/charts/spark-3.1.1/spark-operator-chart/templates/spark-serviceaccount.yaml
+++ b/charts/spark-3.1.1/spark-operator-chart/templates/spark-serviceaccount.yaml
@@ -4,6 +4,11 @@ kind: ServiceAccount
 metadata:
   name: {{ include "spark.serviceAccountName" . }}
   namespace: {{ default .Release.Namespace .Values.sparkJobNamespace }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/spark-3.1.1/spark-operator-chart/templates/webhook-cleanup-job.yaml
+++ b/charts/spark-3.1.1/spark-operator-chart/templates/webhook-cleanup-job.yaml
@@ -3,6 +3,11 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "spark-operator.fullname" . }}-webhook-cleanup
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   annotations:
     {{- toYaml .Values.webhook.cleanupAnnotations | nindent 4 }}
   labels:

--- a/charts/spark-3.1.1/spark-operator-chart/templates/webhook-init-job.yaml
+++ b/charts/spark-3.1.1/spark-operator-chart/templates/webhook-init-job.yaml
@@ -3,6 +3,11 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "spark-operator.fullname" . }}-webhook-init
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
 spec:

--- a/charts/spark-3.1.1/spark-operator-chart/templates/webhook-service.yaml
+++ b/charts/spark-3.1.1/spark-operator-chart/templates/webhook-service.yaml
@@ -3,6 +3,11 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ include "spark-operator.fullname" . }}-webhook
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
 spec:

--- a/charts/spark-3.1.1/spark-operator-chart/values.yaml
+++ b/charts/spark-3.1.1/spark-operator-chart/values.yaml
@@ -41,6 +41,11 @@ serviceAccounts:
     # -- Optional name for the operator service account
     name: ""
 
+#owner References
+ownerReference:
+  overRide: false
+  ownerReferences: {}
+
 # -- Set this if running spark jobs in a different namespace than the operator
 sparkJobNamespace: ""
 

--- a/charts/spark-client/spark-client/spark-client-chart/templates/deployment.yaml
+++ b/charts/spark-client/spark-client/spark-client-chart/templates/deployment.yaml
@@ -2,6 +2,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "spark-client-chart.fullname" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "spark-client-chart.labels" . | nindent 4 }}
 spec:

--- a/charts/spark-client/spark-client/spark-client-chart/templates/imagepull.yaml
+++ b/charts/spark-client/spark-client/spark-client-chart/templates/imagepull.yaml
@@ -3,6 +3,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.defaultPullSecret }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ .Files.Get "files/example-imagepullsecret" | b64enc }}

--- a/charts/spark-client/spark-client/spark-client-chart/templates/rbac.yaml
+++ b/charts/spark-client/spark-client/spark-client-chart/templates/rbac.yaml
@@ -3,6 +3,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "spark-client-chart.fullname" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "spark-client-chart.labels" . | nindent 4 }}
 rules:

--- a/charts/spark-client/spark-client/spark-client-chart/templates/service.yaml
+++ b/charts/spark-client/spark-client/spark-client-chart/templates/service.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "spark-client-chart.fullname" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "spark-client-chart.labels" . | nindent 4 }}
 spec:

--- a/charts/spark-client/spark-client/spark-client-chart/templates/serviceaccount.yaml
+++ b/charts/spark-client/spark-client/spark-client-chart/templates/serviceaccount.yaml
@@ -3,6 +3,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "spark-client-chart.serviceAccountName" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{- include "spark-client-chart.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/spark-client/spark-client/spark-client-chart/values.yaml
+++ b/charts/spark-client/spark-client/spark-client-chart/values.yaml
@@ -27,6 +27,11 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+#owner References
+ownerReference:
+  overRide: false
+  ownerReferences: {}
+
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/charts/spark-hs-2.4.7/spark-hs-chart/templates/configmap.yaml
+++ b/charts/spark-hs-2.4.7/spark-hs-chart/templates/configmap.yaml
@@ -4,6 +4,11 @@ kind: ConfigMap
 metadata:
   name: {{ $componentName }}
   namespace: {{ .Values.tenantNameSpace }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{ include "spark-hs-chart.labels" (dict "componentName" $componentName "context" $) | nindent 4 }}
 data:

--- a/charts/spark-hs-2.4.7/spark-hs-chart/templates/deployment.yaml
+++ b/charts/spark-hs-2.4.7/spark-hs-chart/templates/deployment.yaml
@@ -6,6 +6,11 @@ metadata:
     deployment.kubernetes.io/revision: "1"
   name: {{ $componentName }}
   namespace: {{ .Values.tenantNameSpace }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
 spec:
   progressDeadlineSeconds: {{ .Values.progressDeadlineSeconds }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/spark-hs-2.4.7/spark-hs-chart/templates/rbac.yaml
+++ b/charts/spark-hs-2.4.7/spark-hs-chart/templates/rbac.yaml
@@ -5,6 +5,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $roleName }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels: {{ include "spark-hs-chart.labels" (dict "componentName" $roleName "context" $) | nindent 4 }}
 rules:
 - apiGroups:
@@ -24,6 +29,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ $roleBindingName }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
   {{ include "spark-hs-chart.labels" (dict "componentName" $roleBindingName "context" $) | nindent 4 }}
 roleRef:

--- a/charts/spark-hs-2.4.7/spark-hs-chart/templates/service.yaml
+++ b/charts/spark-hs-2.4.7/spark-hs-chart/templates/service.yaml
@@ -4,6 +4,11 @@ kind: Service
 metadata:
   name: {{ $componentName }}
   namespace: {{ .Values.tenantNameSpace }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     {{ include "spark-hs-chart.labels" (dict "componentName" $componentName "context" $) | nindent 4 }}
 spec:

--- a/charts/spark-hs-2.4.7/spark-hs-chart/templates/serviceaccount.yaml
+++ b/charts/spark-hs-2.4.7/spark-hs-chart/templates/serviceaccount.yaml
@@ -5,6 +5,11 @@ kind: ServiceAccount
 metadata:
   name: {{ $componentName }}
   labels: {{ include "spark-hs-chart.labels" (dict "componentName" $componentName "context" $) | nindent 4 }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   namespace: {{ .Values.tenantNameSpace }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:

--- a/charts/spark-hs-2.4.7/spark-hs-chart/values.yaml
+++ b/charts/spark-hs-2.4.7/spark-hs-chart/values.yaml
@@ -43,7 +43,7 @@ tenantIsUnsecure: false
 #HPE tenant namespace service account
 serviceAccount:
   create: true
-  name: ""
+  name: sparkhs-tenant-sa
   annotations: { }
 
 rbac:
@@ -86,6 +86,11 @@ livenessProbe:
   timeoutSeconds: 1
   failureThreshold: 3
   successThreshold: 1
+
+#owner Reference
+ownerReference:
+  overRide: false
+  ownerReferences: {}
 
 #readiness probe configurations
 readinessProbe:

--- a/charts/spark-hs-3.1.1/spark-hs-chart/templates/configmap.yaml
+++ b/charts/spark-hs-3.1.1/spark-hs-chart/templates/configmap.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "spark-hs-chart.fullname" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "spark-hs-chart.name" . }}
     helm.sh/chart: {{ include "spark-hs-chart.chart" . }}

--- a/charts/spark-hs-3.1.1/spark-hs-chart/templates/deployment.yaml
+++ b/charts/spark-hs-3.1.1/spark-hs-chart/templates/deployment.yaml
@@ -2,6 +2,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "spark-hs-chart.fullname" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "spark-hs-chart.name" . }}
     helm.sh/chart: {{ include "spark-hs-chart.chart" . }}

--- a/charts/spark-hs-3.1.1/spark-hs-chart/templates/imagepull.yaml
+++ b/charts/spark-hs-3.1.1/spark-hs-chart/templates/imagepull.yaml
@@ -3,6 +3,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.defaultPullSecret }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ .Files.Get "files/example-imagepullsecret" | b64enc }}

--- a/charts/spark-hs-3.1.1/spark-hs-chart/templates/rbac.yaml
+++ b/charts/spark-hs-3.1.1/spark-hs-chart/templates/rbac.yaml
@@ -3,6 +3,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "spark-hs-chart.fullname" . }}-cr
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "spark-hs-chart.name" . }}
     helm.sh/chart: {{ include "spark-hs-chart.chart" . }}

--- a/charts/spark-hs-3.1.1/spark-hs-chart/templates/service.yaml
+++ b/charts/spark-hs-3.1.1/spark-hs-chart/templates/service.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "spark-hs-chart.fullname" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "spark-hs-chart.name" . }}
     helm.sh/chart: {{ include "spark-hs-chart.chart" . }}

--- a/charts/spark-hs-3.1.1/spark-hs-chart/templates/serviceaccount.yaml
+++ b/charts/spark-hs-3.1.1/spark-hs-chart/templates/serviceaccount.yaml
@@ -3,6 +3,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "spark-hs-chart.serviceAccountName" . }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "spark-hs-chart.name" . }}
     helm.sh/chart: {{ include "spark-hs-chart.chart" . }}

--- a/charts/spark-hs-3.1.1/spark-hs-chart/values.yaml
+++ b/charts/spark-hs-3.1.1/spark-hs-chart/values.yaml
@@ -29,6 +29,10 @@ serviceAccount:
   create: true
   name: history-server-sa
 
+ownerReference:
+  overRide: false
+  ownerReferences: {}
+
 environment:
 # Note: do not configure Spark history events directory using SPARK_HISTORY_OPTS. It will be
 # configured by this chart based on the values in "pvc" or "hdfs" attribute.


### PR DESCRIPTION
Changes are included in these charts:
- livy-0.8.0
- metastore-2.3.8
- mysql-operator-v0.1.5
- spark-3.1.1
- spark-2.4.7
- spark-client
- spark-hs-2.4.7
- spark-hs-3.1.1