### PR TITLE
Fixes the issue where chart with existing release name cannot be created in a new namespace

### DIFF
--- a/charts/spark-3.1.1/spark-operator-chart/Chart.yaml
+++ b/charts/spark-3.1.1/spark-operator-chart/Chart.yaml
@@ -2,10 +2,6 @@ apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
 version: 1.0.8
-appVersion: latestC
+appVersion: 3.1.1
 keywords:
   - spark
-home: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator
-maintainers:
-  - name: yuchaoran2011
-    email: yuchaoran2011@gmail.com

--- a/charts/spark-3.1.1/spark-operator-chart/templates/_helpers.tpl
+++ b/charts/spark-3.1.1/spark-operator-chart/templates/_helpers.tpl
@@ -81,3 +81,17 @@ Create the name of the service account to be used by spark apps
     {{- toYaml .Values.imagePullSecrets | nindent 8 }}
   {{ end }}
 {{ end }}
+
+{{/*
+Returns the name of cluster role
+*/}}
+{{- define "spark-operator.ClusterRoleName" -}}
+    {{ include "spark-operator.name" . }}-{{ now | date "20060102150405" }}-CR
+{{- end -}}
+
+{{/*
+Returns the name of cluster role binding
+*/}}
+{{- define  "spark-operator.ClusterRoleBindingName" -}}
+    {{ include "spark-operator.name" . }}-{{ now | date "20060102150405" }}-CRB
+{{- end -}}

--- a/charts/spark-3.1.1/spark-operator-chart/templates/_helpers.tpl
+++ b/charts/spark-3.1.1/spark-operator-chart/templates/_helpers.tpl
@@ -86,12 +86,12 @@ Create the name of the service account to be used by spark apps
 Returns the name of cluster role
 */}}
 {{- define "spark-operator.ClusterRoleName" -}}
-    {{ include "spark-operator.name" . }}-{{ now | date "20060102150405" }}-CR
+    {{ include "spark-operator.name" . }}-{{ .Release.Namespace }}-CR
 {{- end -}}
 
 {{/*
 Returns the name of cluster role binding
 */}}
 {{- define  "spark-operator.ClusterRoleBindingName" -}}
-    {{ include "spark-operator.name" . }}-{{ now | date "20060102150405" }}-CRB
+    {{ include "spark-operator.name" . }}-{{ .Release.Namespace }}-CRB
 {{- end -}}

--- a/charts/spark-3.1.1/spark-operator-chart/templates/rbac.yaml
+++ b/charts/spark-3.1.1/spark-operator-chart/templates/rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "spark-operator.fullname" . }}
+  name: {{ include "spark-operator.ClusterRoleName" . }}
   {{- if .Values.ownerReference.overRide }}
   {{- with  .Values.ownerReference.ownerReferences }}
   ownerReferences: {{- toYaml . | nindent 2 }}
@@ -113,7 +113,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "spark-operator.fullname" . }}
+  name: {{ include "spark-operator.ClusterRoleBindingName" . }}
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
 subjects:
@@ -122,6 +122,6 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ include "spark-operator.fullname" . }}
+  name: {{ include "spark-operator.ClusterRoleName" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/spark-3.1.1/spark-operator-chart/values.yaml
+++ b/charts/spark-3.1.1/spark-operator-chart/values.yaml
@@ -39,7 +39,7 @@ serviceAccounts:
     # -- Create a service account for the operator
     create: true
     # -- Optional name for the operator service account
-    name: ""
+    name: "spark-operator"
 
 #owner References
 ownerReference:


### PR DESCRIPTION
- Changes to CR and CRB names. Creating new dynamic names for each release
- Added default service account name for spark operator Service account
- Minor changes to Chart.yaml to correctly reflect version.