### PR TITLE
Support for spark-hs-2.4.7 in 'none' tenants

### DIFF
--- a/charts/common/templates/_volumeMounts.tpl
+++ b/charts/common/templates/_volumeMounts.tpl
@@ -20,6 +20,9 @@ Returns standard volume mounts
   name: sssd-secrets
 - mountPath: "/opt/mapr/kubernetes/ssh-secrets"
   name: ssh-secrets
+{{- end }}
+
+{{- define "common.security.volumeMounts" -}}
 - mountPath: "/opt/mapr/kubernetes/client-secrets"
   name: client-secrets
 - mountPath: "/opt/mapr/kubernetes/server-secrets"

--- a/charts/common/templates/_volumes.tpl
+++ b/charts/common/templates/_volumes.tpl
@@ -46,6 +46,9 @@ Params:
   secret:
     defaultMode: 420
     secretName: ssh
+{{- end }}
+
+{{- define "common.security.volumes" -}}
 - name: client-secrets
   secret:
     defaultMode: 420

--- a/charts/spark-hs-2.4.7/README.md
+++ b/charts/spark-hs-2.4.7/README.md
@@ -18,9 +18,32 @@ To set the tenant namespace use the flag `--set tenantNameSpace=sampletenant` du
 ### Viewing the UI
 After the chart is successfully installed, a message would be printed out to the console with details about how to access the UI.
 
+## Examples
 
-## Uninstalling the Chart
+Install spark history server deployment named 'spark-test-hs' in 'sampletenant' tenant, assuming that tenant type is 'internal' or 'external':
+```shell script
+helm install -f ./spark-hs-chart/values.yaml spark-hs-sampletenant ./spark-hs-chart/ \
+--namespace sampletenant \
+--set tenantNameSpace=sampletenant \
+--set tenantIsUnsecure=false \
+--set eventlogstorage.kind=maprfs
+```
 
-`helm delete spark-hs -n sampletenant`
+Install spark history server deployment named 'spark-test-hs' in 'sampletenant' tenant, assuming that tenant type is 'none'.
+Put attention that 'maprfs' eventlog storage kind is not applicable for 'none' tenants. Instead, 'pvc' should be used.
+This example assumes that 'spark-hs-pvc' PVC has been created or will be created later. Spark-HS server pod will not start
+if 'spark-hs-pvc' doesn't exist. The PVC should have access mode 'ReadWriteMany'.
+```shell script
+helm install -f ./spark-hs-chart/values.yaml spark-hs-sampletenant ./spark-hs-chart/ \
+--namespace sampletenant \
+--set tenantNameSpace=sampletenant \
+--set tenantIsUnsecure=true \
+--set eventlogstorage.kind=pvc \
+--set eventlogstorage.pvcname=spark-hs-pvc
+```
 
+Uninstall spark history server deployment named "spark-test-hs" from 'sampletenant' tenant
+```shell script
+helm uninstall spark-test-hs --namespace sampletenant
+```
 Please note that this won't delete the PVC in case you are using a PVC. PVC will have to be manually deleted.

--- a/charts/spark-hs-2.4.7/spark-hs-chart/templates/configmap.yaml
+++ b/charts/spark-hs-2.4.7/spark-hs-chart/templates/configmap.yaml
@@ -567,13 +567,17 @@ data:
     spark.executor.memory              2g
 
     spark.yarn.historyServer.address spark-hs-container-d46d4fd9d-zvnlf.spark-hs-container-svc.internaltenant.svc.cluster.local:18480
-    spark.history.ui.port 18080
+    spark.history.ui.port {{ .Values.ports.httpPort }}
     # SECURITY BLOCK
     # ALL SECURITY PROPERTIES MUST BE PLACED IN THIS BLOCK
 
     # ssl
-    spark.ssl.historyServer.port 18480
+    spark.ssl.historyServer.port {{ .Values.ports.httpsPort }}
+    {{- if .Values.tenantIsUnsecure }}
+    spark.ssl.enabled false
+    {{ else }}
     spark.ssl.enabled true
+    {{- end }}
     spark.ssl.ui.enabled false
     spark.ssl.fs.enabled true
     spark.ssl.trustStore /opt/mapr/conf/ssl_truststore
@@ -701,19 +705,19 @@ data:
     #########################################################################################################
 
     # Set the spark attributes
-    if [ -d "/opt/mapr/spark/spark-2.4.4" ]; then
-            export SPARK_HOME=/opt/mapr/spark/spark-2.4.4
+    if [ -d "/opt/mapr/spark/spark-2.4.7" ]; then
+            export SPARK_HOME=/opt/mapr/spark/spark-2.4.7
     fi
 
     # Load the hadoop version attributes
-    source /opt/mapr/spark/spark-2.4.4/mapr-util/hadoop-version-picker.sh
+    source /opt/mapr/spark/spark-2.4.7/mapr-util/hadoop-version-picker.sh
     export HADOOP_HOME=$hadoop_home_dir
     export HADOOP_CONF_DIR=$hadoop_conf_dir
 
     # Enable mapr impersonation
     export MAPR_IMPERSONATION_ENABLED=1
 
-    MAPR_HADOOP_CLASSPATH=`/opt/mapr/spark/spark-2.4.4/bin/mapr-classpath.sh`
+    MAPR_HADOOP_CLASSPATH=`/opt/mapr/spark/spark-2.4.7/bin/mapr-classpath.sh`
     MAPR_HADOOP_JNI_PATH=`hadoop jnipath`
     MAPR_SPARK_CLASSPATH="$MAPR_HADOOP_CLASSPATH"
 
@@ -723,17 +727,17 @@ data:
     export LD_LIBRARY_PATH="$MAPR_HADOOP_JNI_PATH:$LD_LIBRARY_PATH"
 
     # Load the classpath generator script
-    source /opt/mapr/spark/spark-2.4.4/mapr-util/generate-classpath.sh
+    source /opt/mapr/spark/spark-2.4.7/mapr-util/generate-classpath.sh
 
     # Calculate hive jars to include in classpath
-    generate_compatible_classpath "spark" "2.4.4" "hive"
+    generate_compatible_classpath "spark" "2.4.7" "hive"
     MAPR_HIVE_CLASSPATH=${generated_classpath}
     if [ ! -z "$MAPR_HIVE_CLASSPATH" ]; then
       MAPR_SPARK_CLASSPATH="$MAPR_SPARK_CLASSPATH:$MAPR_HIVE_CLASSPATH"
     fi
 
     # Calculate hbase jars to include in classpath
-    generate_compatible_classpath "spark" "2.4.4" "hbase"
+    generate_compatible_classpath "spark" "2.4.7" "hbase"
     MAPR_HBASE_CLASSPATH=${generated_classpath}
     if [ ! -z "$MAPR_HBASE_CLASSPATH" ]; then
       MAPR_SPARK_CLASSPATH="$MAPR_SPARK_CLASSPATH:$MAPR_HBASE_CLASSPATH"
@@ -756,7 +760,7 @@ data:
     # scala
     export SCALA_VERSION=2.11
     export SPARK_SCALA_VERSION=$SCALA_VERSION
-    export SCALA_HOME=/opt/mapr/spark/spark-2.4.4/scala
+    export SCALA_HOME=/opt/mapr/spark/spark-2.4.7/scala
     export SCALA_LIBRARY_PATH=$SCALA_HOME/lib
 
     # Use a fixed identifier for pid files

--- a/charts/spark-hs-2.4.7/spark-hs-chart/templates/deployment.yaml
+++ b/charts/spark-hs-2.4.7/spark-hs-chart/templates/deployment.yaml
@@ -74,10 +74,16 @@ spec:
           {{- if ( eq .Values.eventlogstorage.kind "pvc") }}
           {{- include "spark-hs-chart.pvcVolumeMount" . | nindent 12 }}
           {{- end }}
+          {{- if not .Values.tenantIsUnsecure }}
+          {{- include "common.security.volumeMounts" . | nindent 12 }}
+          {{- end }}
       volumes:
       {{- include "common.volumes" (dict "configmapName" $configmapName "componentName" $componentName) | nindent 8 }}
       {{- if ( eq .Values.eventlogstorage.kind "pvc") }}
       {{- include "spark-hs-chart.pvcVolume" . | nindent 8 }}
+      {{- end }}
+      {{- if not .Values.tenantIsUnsecure }}
+      {{- include "common.security.volumes" . | nindent 8 }}
       {{- end }}
       securityContext:
       {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/spark-hs-2.4.7/spark-hs-chart/templates/service.yaml
+++ b/charts/spark-hs-2.4.7/spark-hs-chart/templates/service.yaml
@@ -18,4 +18,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "common.selectorLabels" (dict "componentName" $componentName ) | nindent 4 }}
+    {{- include "common.selectorLabels" (dict "componentName" .Chart.Name ) | nindent 4 }}

--- a/charts/spark-hs-2.4.7/spark-hs-chart/values.yaml
+++ b/charts/spark-hs-2.4.7/spark-hs-chart/values.yaml
@@ -46,7 +46,7 @@ tenantIsUnsecure: false
 serviceAccount:
   # Specifies whether a service account should be created
   # This will look for existing hpe-{{ ReleaseNamespace }} ServiceAccount and use it if it exists and creates when it is not present
-  create: true
+  create: false
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use. Please only use the tenant Service Account
@@ -57,7 +57,7 @@ serviceAccount:
 #Create RBAC for the Service Account
 rbac:
   #RBAC is created only when this flag is true and ServiceAccount.create is also true
-  create: true
+  create: false
 
 podSecurityContext: {}
 


### PR DESCRIPTION
- split volumes lists into 2 parts
- fix spark version
- fix spark-hs nodeport service
- disable sa/rbac creation by default
- add separate examples for 'none' and 'internal/external' tenant types