### PR TITLE
common SA names for spark apps and update to example CRs

### DIFF
--- a/charts/spark-2.4.7/spark-operator-chart/values.yaml
+++ b/charts/spark-2.4.7/spark-operator-chart/values.yaml
@@ -30,7 +30,7 @@ serviceAccounts:
     # -- Create a service account for spark apps
     create: true
     # -- Optional name for the spark service account
-    name: "spark"
+    name: "spark-sa"
   sparkoperator:
     # -- Create a service account for the operator
     create: true

--- a/examples/spark-2.4.7/advancedsamples/pyspark-with-dependencies.yaml
+++ b/examples/spark-2.4.7/advancedsamples/pyspark-with-dependencies.yaml
@@ -31,7 +31,7 @@ spec:
   sparkVersion: 2.4.7
   pythonVersion: "3"
   mode: cluster
-  image: gcr.io/mapr-252711/spark-py-2.4.7:202106220630P141
+  image: gcr.io/mapr-252711/spark-py-2.4.7:v2.4.7
   imagePullPolicy: Always
   mainApplicationFile: local:///maprfs-csi/path/to/main/file/app.py
   deps:
@@ -47,9 +47,10 @@ spec:
     memory: "512m"
     labels:
       version: 2.4.7
-    # Note: You do not need to specify a serviceAccount
-    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
-    #serviceAccount: hpe-sampletenant
+    # Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-2.4.7 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation
+    serviceAccount: spark-sa
     volumeMounts:
       - name: maprfs-volume
         mountPath: /maprfs-csi

--- a/examples/spark-2.4.7/advancedsamples/spark-affinity-pi.yaml
+++ b/examples/spark-2.4.7/advancedsamples/spark-affinity-pi.yaml
@@ -30,7 +30,7 @@ spec:
   type: Scala
   sparkVersion: 2.4.7
   mode: cluster
-  image: gcr.io/mapr-252711/spark-2.4.7:202106220630P141
+  image: gcr.io/mapr-252711/spark-2.4.7:v2.4.7
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
   mainApplicationFile: "local:///opt/mapr/spark/spark-2.4.7/examples/jars/spark-examples_2.12-2.4.7.4-mapr-701.jar"
@@ -53,9 +53,10 @@ spec:
     memory: "512m"
     labels:
       version: 2.4.7
-    # Note: You do not need to specify a serviceAccount
-    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
-    #serviceAccount: hpe-sampletenant
+    # Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-2.4.7 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation
+    serviceAccount: spark-sa
   executor:
     affinity:
       nodeAffinity:

--- a/examples/spark-2.4.7/advancedsamples/spark-aws-s3a-wc.yaml
+++ b/examples/spark-2.4.7/advancedsamples/spark-aws-s3a-wc.yaml
@@ -36,7 +36,7 @@ spec:
   type: Scala
   sparkVersion: 2.4.7
   mode: cluster
-  image: gcr.io/mapr-252711/spark-2.4.7:202106220630P141
+  image: gcr.io/mapr-252711/spark-2.4.7:v2.4.7
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.JavaWordCount
   mainApplicationFile: "local:///opt/mapr/spark/spark-2.4.7/examples/jars/spark-examples_2.12-2.4.7.4-mapr-701.jar"
@@ -52,9 +52,10 @@ spec:
     memory: "512m"
     labels:
       version: 2.4.7
-    # Note: You do not need to specify a serviceAccount
-    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
-    #serviceAccount: hpe-sampletenant
+    # Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-2.4.7 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation
+    serviceAccount: spark-sa
   executor:
     cores: 1
     coreLimit: "1000m"

--- a/examples/spark-2.4.7/advancedsamples/spark-solr-kerberos.yaml
+++ b/examples/spark-2.4.7/advancedsamples/spark-solr-kerberos.yaml
@@ -60,7 +60,7 @@ spec:
   type: Scala
   sparkVersion: 2.4.7
   mode: cluster
-  image: gcr.io/mapr-252711/spark-2.4.7:202106220630P141
+  image: gcr.io/mapr-252711/spark-2.4.7:v2.4.7
   imagePullPolicy: Always
   mainApplicationFile: maprfs:///path/to/application.jar
   mainClass: your.main.Class
@@ -77,7 +77,10 @@ spec:
     memory: "512m"
     labels:
       version: 2.4.7
-#      serviceAccount: hpe-sampletenant
+    # Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-2.4.7 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation
+    serviceAccount: spark-sa
     # Driver SOLR+KERBEROS-specific options
     javaOptions: "-Dsolr.kerberos.jaas.appname=[config-name-from-jaas.conf] -Djava.security.krb5.conf=[path-to-mounted-kerberos-config]"
     env:

--- a/examples/spark-2.4.7/clients/sparkclient.yaml
+++ b/examples/spark-2.4.7/clients/sparkclient.yaml
@@ -53,7 +53,7 @@ spec:
             defaultMode: 420
       containers:
         - name: sparkcli
-          image: gcr.io/mapr-252711/spark-client-2.4.7:202106220630P141
+          image: gcr.io/mapr-252711/spark-client-2.4.7:v2.4.7
           command:
             - /tini
             - '--'
@@ -86,7 +86,10 @@ spec:
             - name: client-secrets
               mountPath: /opt/mapr/kubernetes/client-secrets
       restartPolicy: Always
-      serviceAccountName: hpe-sampletenant
+      # Note: ServiceAccount is set to the default ServiceAccount as per the
+      #       spark-2.4.7 helm chart. Please update the Service Account name if you had
+      #       used a different ServiceAccount during the helm chart installation
+      serviceAccountName: spark-sa
       automountServiceAccountToken: true
       imagePullSecrets:
         - name: imagepull

--- a/examples/spark-2.4.7/pyspark-wc.yaml
+++ b/examples/spark-2.4.7/pyspark-wc.yaml
@@ -31,7 +31,7 @@ spec:
   sparkVersion: 2.4.7
   pythonVersion: "3"
   mode: cluster
-  image: gcr.io/mapr-252711/spark-py-2.4.7:202106220630P141
+  image: gcr.io/mapr-252711/spark-py-2.4.7:v2.4.7
   imagePullPolicy: Always
   mainApplicationFile: local:///opt/mapr/spark/spark-2.4.7/examples/src/main/python/wordcount.py
   restartPolicy:
@@ -46,9 +46,10 @@ spec:
     memory: "512m"
     labels:
       version: 2.4.7
-    # Note: You do not need to specify a serviceAccount
-    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
-    #serviceAccount: hpe-sampletenant
+    # Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-2.4.7 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation
+    serviceAccount: spark-sa
   executor:
     cores: 1
     coreLimit: "1000m"

--- a/examples/spark-2.4.7/r-spark-naive-bayes.yaml
+++ b/examples/spark-2.4.7/r-spark-naive-bayes.yaml
@@ -30,7 +30,7 @@ spec:
   type: R
   sparkVersion: 2.4.7
   mode: cluster
-  image: gcr.io/mapr-252711/spark-r-2.4.7:202106220630P141
+  image: gcr.io/mapr-252711/spark-r-2.4.7:v2.4.7
   imagePullPolicy: Always
   mainApplicationFile: local:///opt/mapr/spark/spark-2.4.7/examples/src/main/r/ml/naiveBayes.R
   restartPolicy:
@@ -43,9 +43,10 @@ spec:
     memory: "512m"
     labels:
       version: 2.4.7
-    # Note: You do not need to specify a serviceAccount
-    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
-    #serviceAccount: hpe-sampletenant
+    # Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-2.4.7 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation
+    serviceAccount: spark-sa
   executor:
     cores: 1
     coreLimit: "1000m"

--- a/examples/spark-2.4.7/spark-dtap-wc.yaml
+++ b/examples/spark-2.4.7/spark-dtap-wc.yaml
@@ -39,7 +39,7 @@ spec:
   deps:
     jars:
       - local:///opt/bdfs/bluedata-dtap.jar
-  image: gcr.io/mapr-252711/spark-2.4.7:202106220630P141
+  image: gcr.io/mapr-252711/spark-2.4.7:v2.4.7
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.JavaWordCount
   mainApplicationFile: "local:///opt/mapr/spark/spark-2.4.7/examples/jars/spark-examples_2.12-2.4.7.4-mapr-701.jar"
@@ -56,9 +56,10 @@ spec:
     labels:
       version: 2.4.7
       hpecp.hpe.com/dtap: hadoop2 # enabling dtap side-car container for driver pod
-    # Note: You do not need to specify a serviceAccount
-    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
-    #serviceAccount: hpe-sampletenant
+    # Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-2.4.7 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation
+    serviceAccount: spark-sa
   executor:
     cores: 1
     coreLimit: "1000m"

--- a/examples/spark-2.4.7/spark-hive.yaml
+++ b/examples/spark-2.4.7/spark-hive.yaml
@@ -30,7 +30,7 @@ spec:
   type: Scala
   sparkVersion: 2.4.7
   mode: cluster
-  image: gcr.io/mapr-252711/spark-2.4.7:202106220630P141
+  image: gcr.io/mapr-252711/spark-2.4.7:v2.4.7
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.sql.hive.SparkHiveExample
   mainApplicationFile: "local:///opt/mapr/spark/spark-2.4.7/examples/jars/spark-examples_2.12-2.4.7.4-mapr-701.jar"
@@ -55,9 +55,10 @@ spec:
     memory: "512m"
     labels:
       version: 2.4.7
-    # Note: You do not need to specify a serviceAccount
-    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
-    #serviceAccount: hpe-sampletenant
+    # Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-2.4.7 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation
+    serviceAccount: spark-sa
   volumes:
   - name: hive-site-volume
     configMap:

--- a/examples/spark-2.4.7/spark-pi-scheduled.yaml
+++ b/examples/spark-2.4.7/spark-pi-scheduled.yaml
@@ -17,7 +17,7 @@ spec:
     type: Scala
     sparkVersion: 2.4.7
     mode: cluster
-    image: gcr.io/mapr-252711/spark-2.4.7:202106220630P141
+    image: gcr.io/mapr-252711/spark-2.4.7:v2.4.7
     imagePullPolicy: Always
     imagePullSecrets:
       - imagepull
@@ -31,9 +31,10 @@ spec:
       memory: "512m"
       labels:
         version: 2.4.7
-      # Note: You do not need to specify a serviceAccount
-      #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
-      #serviceAccount: hpe-sampletenant
+      # Note: ServiceAccount is set to the default ServiceAccount as per the
+      #       spark-2.4.7 helm chart. Please update the Service Account name if you had
+      #       used a different ServiceAccount during the helm chart installation
+      serviceAccount: spark-sa
     executor:
       cores: 1
       coreLimit: "1000m"

--- a/examples/spark-2.4.7/spark-pi.yaml
+++ b/examples/spark-2.4.7/spark-pi.yaml
@@ -30,7 +30,7 @@ spec:
   type: Scala
   sparkVersion: 2.4.7
   mode: cluster
-  image: gcr.io/mapr-252711/spark-2.4.7:202106220630P141
+  image: gcr.io/mapr-252711/spark-2.4.7:v2.4.7
   imagePullPolicy: Always
   imagePullSecrets:
   - imagepull
@@ -44,9 +44,10 @@ spec:
     memory: "512m"
     labels:
       version: 2.4.7
-    # Note: You do not need to specify a serviceAccount
-    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
-    #serviceAccount: hpe-sampletenant
+    # Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-2.4.7 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation
+    serviceAccount: spark-sa
   executor:
     cores: 1
     coreLimit: "1000m"

--- a/examples/spark-2.4.7/spark-streaming-queue.yaml
+++ b/examples/spark-2.4.7/spark-streaming-queue.yaml
@@ -30,7 +30,7 @@ spec:
   type: Scala
   sparkVersion: 2.4.7
   mode: cluster
-  image: gcr.io/mapr-252711/spark-2.4.7:202106220630P141
+  image: gcr.io/mapr-252711/spark-2.4.7:v2.4.7
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.streaming.QueueStream
   mainApplicationFile: "local:///opt/mapr/spark/spark-2.4.7/examples/jars/spark-examples_2.12-2.4.7.4-mapr-701.jar"
@@ -44,9 +44,10 @@ spec:
     memory: "512m"
     labels:
       version: 2.4.7
-    # Note: You do not need to specify a serviceAccount
-    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
-    #serviceAccount: hpe-sampletenant
+    # Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-2.4.7 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation
+    serviceAccount: spark-sa
   executor:
     cores: 1
     coreLimit: "1000m"

--- a/examples/spark-2.4.7/spark-wc.yaml
+++ b/examples/spark-2.4.7/spark-wc.yaml
@@ -30,7 +30,7 @@ spec:
   type: Java
   sparkVersion: 2.4.7
   mode: cluster
-  image: gcr.io/mapr-252711/spark-2.4.7:202106220630P141
+  image: gcr.io/mapr-252711/spark-2.4.7:v2.4.7
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.JavaWordCount
   mainApplicationFile: "local:///opt/mapr/spark/spark-2.4.7/examples/jars/spark-examples_2.12-2.4.7.4-mapr-701.jar"
@@ -46,9 +46,10 @@ spec:
     memory: "512m"
     labels:
       version: 2.4.7
-    # Note: You do not need to specify a serviceAccount
-    #       it will be auto-generated referencing the pre-existing "hpe-<namespace>"
-    #serviceAccount: hpe-sampletenant
+    # Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-2.4.7 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation
+    serviceAccount: spark-sa
   executor:
     cores: 1
     coreLimit: "1000m"

--- a/examples/spark-3.1.1/crs/deltalake/spark-delta-local.yaml
+++ b/examples/spark-3.1.1/crs/deltalake/spark-delta-local.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: "gcr.io/mapr-252711/apache-spark-3.1.1:202107111721"
+  image: "gcr.io/mapr-252711/apache-spark-3.1.1:v3.1.1"
   imagePullPolicy: Always
   imagePullSecrets:
     - imagepull
@@ -41,7 +41,9 @@ spec:
     memory: "512m"
     labels:
       version: 3.1.1
-    # Note: If you run app in tenant namespace - change serviceAccount name to "hpe-<namespace>"
+    # Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-3.1.1 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation
     serviceAccount: spark
     volumeMounts:
       - name: "test-volume"

--- a/examples/spark-3.1.1/crs/deltalake/spark-delta-s3-py.yaml
+++ b/examples/spark-3.1.1/crs/deltalake/spark-delta-s3-py.yaml
@@ -22,7 +22,7 @@ spec:
   type: Python
   pythonVersion: "3"
   mode: cluster
-  image: "gcr.io/mapr-252711/apache-spark-py-3.1.1:202107261554"
+  image: "gcr.io/mapr-252711/apache-spark-py-3.1.1:v3.1.1"
   imagePullPolicy: Always
   imagePullSecrets:
     - imagepull
@@ -36,7 +36,9 @@ spec:
     memory: "512m"
     labels:
       version: 3.1.1
-    # Note: If you run app in tenant namespace - change serviceAccount name to "hpe-<namespace>"
+    # Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-3.1.1 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation
     serviceAccount: spark
   executor:
     cores: 1

--- a/examples/spark-3.1.1/crs/deltalake/spark-delta-s3.yaml
+++ b/examples/spark-3.1.1/crs/deltalake/spark-delta-s3.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: "gcr.io/mapr-252711/apache-spark-3.1.1:202107111721"
+  image: "gcr.io/mapr-252711/apache-spark-3.1.1:v3.1.1"
   imagePullPolicy: Always
   imagePullSecrets:
     - imagepull
@@ -36,7 +36,9 @@ spec:
     memory: "512m"
     labels:
       version: 3.1.1
-    # Note: If you run app in tenant namespace - change serviceAccount name to "hpe-<namespace>"
+    # Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-3.1.1 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation
     serviceAccount: spark
   executor:
     cores: 1

--- a/examples/spark-3.1.1/crs/spark-dtap-wc.yaml
+++ b/examples/spark-3.1.1/crs/spark-dtap-wc.yaml
@@ -32,7 +32,7 @@ spec:
   deps:
     jars:
       - local:///opt/bdfs/bluedata-dtap.jar
-  image: gcr.io/mapr-252711/apache-spark-3.1.1:202107111721
+  image: gcr.io/mapr-252711/apache-spark-3.1.1:v3.1.1
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.JavaWordCount
   mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.1.1.jar"
@@ -49,7 +49,9 @@ spec:
     labels:
       version: 3.1.1
       hpecp.hpe.com/dtap: hadoop2 # enabling dtap side-car container for driver pod
-    # Note: If you run app in tenant namespace - change serviceAccount name to "hpe-<namespace>"
+    # Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-3.1.1 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation
     serviceAccount: spark
   executor:
     cores: 1

--- a/examples/spark-3.1.1/crs/spark-pi-configmap.yaml
+++ b/examples/spark-3.1.1/crs/spark-pi-configmap.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: "gcr.io/mapr-252711/apache-spark-3.1.1:202107111721"
+  image: "gcr.io/mapr-252711/apache-spark-3.1.1:v3.1.1"
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
   mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.1.1.jar"
@@ -38,7 +38,9 @@ spec:
     memory: "512m"
     labels:
       version: 3.1.1
-    # Note: If you run app in tenant namespace - change serviceAccount name to "hpe-<namespace>"
+    # Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-3.1.1 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation
     serviceAccount: spark
     volumeMounts:
       - name: config-vol

--- a/examples/spark-3.1.1/crs/spark-pi-custom-resource.yaml
+++ b/examples/spark-3.1.1/crs/spark-pi-custom-resource.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: "gcr.io/mapr-252711/apache-spark-3.1.1:202107111721"
+  image: "gcr.io/mapr-252711/apache-spark-3.1.1:v3.1.1"
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
   mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.5.jar"
@@ -39,7 +39,9 @@ spec:
     memory: "512m"
     labels:
       version: 2.4.5
-    # Note: If you run app in tenant namespace - change serviceAccount name to "hpe-<namespace>"
+    # Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-3.1.1 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation
     serviceAccount: spark
     volumeMounts:
       - name: "test-volume"

--- a/examples/spark-3.1.1/crs/spark-pi-pvc-hs-enabled.yaml
+++ b/examples/spark-3.1.1/crs/spark-pi-pvc-hs-enabled.yaml
@@ -24,7 +24,7 @@ spec:
     spark.eventLog.dir: "/hs/mount/path/in/pod"
   type: Scala
   mode: cluster
-  image: "gcr.io/mapr-252711/apache-spark-3.1.1:202107111721"
+  image: "gcr.io/mapr-252711/apache-spark-3.1.1:v3.1.1"
   imagePullPolicy: Always
   imagePullSecrets:
     - imagepull
@@ -43,7 +43,9 @@ spec:
     memory: "512m"
     labels:
       version: 3.1.1
-    # Note: If you run app in tenant namespace - change serviceAccount name to "hpe-<namespace>"
+    # Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-3.1.1 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation
     serviceAccount: spark
     volumeMounts:
       - mountPath: "/hs/mount/path/in/pod"

--- a/examples/spark-3.1.1/crs/spark-pi-schedule.yaml
+++ b/examples/spark-3.1.1/crs/spark-pi-schedule.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     type: Scala
     mode: cluster
-    image: "gcr.io/mapr-252711/apache-spark-3.1.1:202107111721"
+    image: "gcr.io/mapr-252711/apache-spark-3.1.1:v3.1.1"
     imagePullPolicy: Always
     mainClass: org.apache.spark.examples.SparkPi
     mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.1.1.jar"
@@ -38,8 +38,10 @@ spec:
       memory: "512m"
       labels:
         version: 3.1.1
-      # Note: If you run app in tenant namespace - change serviceAccount name to "hpe-<namespace>"
-      serviceAccount: spark
+    # Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-3.1.1 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation
+    serviceAccount: spark
     executor:
       cores: 1
       coreLimit: "1200m"

--- a/examples/spark-3.1.1/crs/spark-pi.yaml
+++ b/examples/spark-3.1.1/crs/spark-pi.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: "gcr.io/mapr-252711/apache-spark-3.1.1:202107111721"
+  image: "gcr.io/mapr-252711/apache-spark-3.1.1:v3.1.1"
   imagePullPolicy: Always
   imagePullSecrets:
     - imagepull
@@ -41,7 +41,9 @@ spec:
     memory: "512m"
     labels:
       version: 3.1.1
-    # Note: If you run app in tenant namespace - change serviceAccount name to "hpe-<namespace>"
+    # Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-3.1.1 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation
     serviceAccount: spark
     volumeMounts:
       - name: "test-volume"

--- a/examples/spark-3.1.1/crs/spark-py-pi.yaml
+++ b/examples/spark-3.1.1/crs/spark-py-pi.yaml
@@ -25,7 +25,7 @@ spec:
   type: Python
   pythonVersion: "3"
   mode: cluster
-  image: "gcr.io/mapr-252711/apache-spark-py-3.1.1:202107261554"
+  image: "gcr.io/mapr-252711/apache-spark-py-3.1.1:v3.1.1"
   imagePullPolicy: Always
   imagePullSecrets:
     - imagepull
@@ -43,7 +43,9 @@ spec:
     memory: "512m"
     labels:
       version: 3.1.1
-    # Note: If you run app in tenant namespace - change serviceAccount name to "hpe-<namespace>"
+    # Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-3.1.1 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation
     serviceAccount: spark
   executor:
     cores: 1

--- a/examples/spark-3.1.2/crs/deltalake/spark-delta-local.yaml
+++ b/examples/spark-3.1.2/crs/deltalake/spark-delta-local.yaml
@@ -41,8 +41,9 @@ spec:
     memory: "512m"
     labels:
       version: 3.1.2
-    # Note: If you run app in tenant namespace - change serviceAccount name to "hpe-<namespace>"
-    serviceAccount: spark
+# Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-3.1.1 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation     serviceAccount: spark
     volumeMounts:
       - name: "test-volume"
         mountPath: "/tmp"

--- a/examples/spark-3.1.2/crs/deltalake/spark-delta-s3-py.yaml
+++ b/examples/spark-3.1.2/crs/deltalake/spark-delta-s3-py.yaml
@@ -36,8 +36,9 @@ spec:
     memory: "512m"
     labels:
       version: 3.1.2
-    # Note: If you run app in tenant namespace - change serviceAccount name to "hpe-<namespace>"
-    serviceAccount: spark
+# Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-3.1.1 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation     serviceAccount: spark
   executor:
     cores: 1
     instances: 1

--- a/examples/spark-3.1.2/crs/deltalake/spark-delta-s3.yaml
+++ b/examples/spark-3.1.2/crs/deltalake/spark-delta-s3.yaml
@@ -36,8 +36,9 @@ spec:
     memory: "512m"
     labels:
       version: 3.1.2
-    # Note: If you run app in tenant namespace - change serviceAccount name to "hpe-<namespace>"
-    serviceAccount: spark
+# Note: ServiceAccount is set to the default ServiceAccount as per the
+    #       spark-3.1.1 helm chart. Please update the Service Account name if you had
+    #       used a different ServiceAccount during the helm chart installation     serviceAccount: spark
   executor:
     cores: 1
     instances: 1


### PR DESCRIPTION
- Changing default SA name for 2.4.7 Spark Apps to avoid name colision when both operators are installed in the same namespace
- Updating SA name for spark-2.4.7 apps in the examples
- Updating image tag for spark-2.4.7 apps to v2.4.7
- updating image tag for spark-3.1.1 apps to v3.1.1
