### PR TITLE
[EZSPA-318] Spark hs 3.1.2 port conflict

### DIFF
--- a/charts/spark-hs-3.1.2/spark-hs-chart/templates/_helpers.tpl
+++ b/charts/spark-hs-3.1.2/spark-hs-chart/templates/_helpers.tpl
@@ -132,7 +132,6 @@ Return ports
   containerPort: {{ include "spark-hs-chart.getHttpPortSparkHsUI" . }}
 - name: "ssh"
   protocol: "TCP"
-  hostPort: {{ .Values.ports.sshHostPort }}
   containerPort: {{ .Values.ports.sshPort }}
 {{- end }}
 
@@ -203,8 +202,6 @@ return env for containers
 */}}
 {{- define "spark-hs-chart.env" -}}
 {{ include "common.defaultEnv" (dict "containerName" .Chart.Name) }}
-- name: SSH_PORT
-  value: {{ .Values.ports.sshHostPort | quote }}
 {{- end }}
 
 {/*

--- a/charts/spark-hs-3.1.2/spark-hs-chart/values.yaml
+++ b/charts/spark-hs-3.1.2/spark-hs-chart/values.yaml
@@ -68,7 +68,6 @@ service:
 #container ports
 ports:
   sshPort: 22
-  sshHostPort: 7779
   httpPort: 18080
   httpsPort: 18480
 


### PR DESCRIPTION
sshHostPort: 7779 - this is unnecessary for helm chart, this port used when Spark HS was started by tenant. Now this port limits worker nodes where SparkHS can be started.