### PR TITLE
[EZSPA-319] Name of the service should be mutable

### DIFF
--- a/charts/spark-hs-3.1.2/spark-hs-chart/templates/_helpers.tpl
+++ b/charts/spark-hs-3.1.2/spark-hs-chart/templates/_helpers.tpl
@@ -210,5 +210,5 @@ return volume mounts for containers
 {{- define "spark-hs-chart.volumeMounts" -}}
 {{ include "common.volumeMounts" . }}
 - name: logs
-  mountPath: "/opt/mapr/spark/{{ .Values.sparkVersion }}/logs"
+  mountPath: "/opt/mapr/spark/spark-{{ .Values.sparkVersion }}/logs"
 {{- end }}

--- a/charts/spark-hs-3.1.2/spark-hs-chart/templates/_helpers.tpl
+++ b/charts/spark-hs-3.1.2/spark-hs-chart/templates/_helpers.tpl
@@ -210,5 +210,5 @@ return volume mounts for containers
 {{- define "spark-hs-chart.volumeMounts" -}}
 {{ include "common.volumeMounts" . }}
 - name: logs
-  mountPath: "/opt/mapr/spark/spark-{{ .Values.sparkVersion }}/logs"
+  mountPath: "/opt/mapr/spark/{{ .Values.sparkVersion }}/logs"
 {{- end }}

--- a/charts/spark-hs-3.1.2/spark-hs-chart/templates/service.yaml
+++ b/charts/spark-hs-3.1.2/spark-hs-chart/templates/service.yaml
@@ -16,6 +16,6 @@ spec:
     - port: {{ include "spark-hs-chart.getHttpPortSparkHsUI" . }}
       targetPort: {{ include "spark-hs-chart.getHttpPortSparkHsUI" . }}
       protocol: TCP
-      name: http
+      name: {{- if .Values.tenantIsUnsecure }} http {{ else }} https {{- end }}
   selector:
     {{- include "common.selectorLabels" (dict "componentName" .Chart.Name ) | nindent 4 }}


### PR DESCRIPTION
On serviceEndpoint name value we need to check if isClusterUnsecure is set to false. If it's false - name should be https. If it's true - http.