### PR TITLE
Fix webhook jobs

### DIFF
--- a/charts/spark-2.4.7/spark-operator-chart/templates/webhook-cleanup-job.yaml
+++ b/charts/spark-2.4.7/spark-operator-chart/templates/webhook-cleanup-job.yaml
@@ -51,4 +51,6 @@ spec:
           -H \"Content-Type: application/json\" \
           --data \"{\\\"kind\\\":\\\"DeleteOptions\\\",\\\"apiVersion\\\":\\\"batch/v1\\\",\\\"propagationPolicy\\\":\\\"Foreground\\\"}\" \
           https://kubernetes.default.svc/apis/batch/v1/namespaces/{{ .Release.Namespace }}/jobs/{{ include "spark-operator.fullname" . }}-webhook-init"
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
 {{ end }}

--- a/charts/spark-2.4.7/spark-operator-chart/templates/webhook-init-job.yaml
+++ b/charts/spark-2.4.7/spark-operator-chart/templates/webhook-init-job.yaml
@@ -32,4 +32,6 @@ spec:
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
         command: ["/usr/bin/gencerts.sh", "-n", "{{ .Release.Namespace }}", "-s", "{{ include "spark-operator.fullname" . }}-webhook", "-p"]
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
 {{ end }}

--- a/charts/spark-3.1.2/spark-operator-chart/templates/webhook-cleanup-job.yaml
+++ b/charts/spark-3.1.2/spark-operator-chart/templates/webhook-cleanup-job.yaml
@@ -51,4 +51,6 @@ spec:
           -H \"Content-Type: application/json\" \
           --data \"{\\\"kind\\\":\\\"DeleteOptions\\\",\\\"apiVersion\\\":\\\"batch/v1\\\",\\\"propagationPolicy\\\":\\\"Foreground\\\"}\" \
           https://kubernetes.default.svc/apis/batch/v1/namespaces/{{ .Release.Namespace }}/jobs/{{ include "spark-operator.fullname" . }}-webhook-init"
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
 {{ end }}

--- a/charts/spark-3.1.2/spark-operator-chart/templates/webhook-init-job.yaml
+++ b/charts/spark-3.1.2/spark-operator-chart/templates/webhook-init-job.yaml
@@ -32,4 +32,6 @@ spec:
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
         command: ["/usr/bin/gencerts.sh", "-n", "{{ .Release.Namespace }}", "-s", "{{ include "spark-operator.fullname" . }}-webhook", "-p"]
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
 {{ end }}


### PR DESCRIPTION
ECP env requires resource limits to be specified. Fixed by enabling resource requests by default.