### PR TITLE
Provide a variable in values.yaml to explicitly set which version of Livy is used

### DIFF
--- a/charts/livy/README.md
+++ b/charts/livy/README.md
@@ -17,11 +17,11 @@ Please note:
 
 ### Install with different version
 To install livy-0.5.0 with spark-2.4.7 support use the flags:  
-`--set image.imageName=livy-0.5.0 --set image.tag=202106291513C --set sparkVersion=spark-2.4.7 --set sessionRecovery.kind=zookeeper --set deImage=spark-2.4.7:202106220630P141`
+`--set image.imageName=livy-0.5.0 --set image.tag=202106291513C --set livyVersion=livy-0.5.0 --set deImage=spark-2.4.7:202106220630P141`
 
 #### Installing in a non DF Tenant
 To install the helm chart in tenant type 'none' Namespace use the flag:  
-`--set tenantIsUnsecure=true `
+`--set tenantIsUnsecure=true`
 
 ##### Using custom keystore
 To use a custom keystore, you'll need to create a secret with that keystore file in tenant namespace manually.

--- a/charts/livy/livy-chart/templates/_helpers.tpl
+++ b/charts/livy/livy-chart/templates/_helpers.tpl
@@ -36,8 +36,8 @@ Common labels
 {{- define "livy-chart.labels" -}}
 helm.sh/chart: {{ include "livy-chart.chart" . }}
 {{ include "livy-chart.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- if .Values.livyVersion }}
+app.kubernetes.io/version: {{ .Values.livyVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
@@ -138,7 +138,7 @@ return volume mounts for containers
 {{- end }}
 {{- if eq .Values.sessionRecovery.kind "pvc" }}
 - name: livy-sessionstore
-  mountPath: "/opt/mapr/livy/livy-{{ .Chart.AppVersion }}/session-store"
+  mountPath: "/opt/mapr/livy/livy-{{ .Values.livyVersion }}/session-store"
 {{- end }}
 {{- if .Values.livySsl.useCustomKeystore }}
 - name: livy-secret-ssl
@@ -147,7 +147,7 @@ return volume mounts for containers
 - name: livy-extra-configs
   mountPath: /opt/mapr/kubernetes/livy-secret-configs
 - name: logs
-  mountPath: /opt/mapr/livy/livy-{{ .Chart.AppVersion }}/logs
+  mountPath: /opt/mapr/livy/livy-{{ .Values.livyVersion }}/logs
 {{- end }}
 
 {{/*

--- a/charts/livy/livy-chart/templates/configmap.yaml
+++ b/charts/livy/livy-chart/templates/configmap.yaml
@@ -31,7 +31,7 @@ data:
     {{- else if eq .Values.sessionRecovery.kind "pvc" }}
     livy.server.recovery.mode = recovery
     livy.server.recovery.state-store = filesystem
-    livy.server.recovery.state-store.url = file:///opt/mapr/livy/livy-{{ .Chart.AppVersion }}/session-store
+    livy.server.recovery.state-store.url = file:///opt/mapr/livy/livy-{{ .Values.livyVersion }}/session-store
     {{- else }}
     livy.server.recovery.mode = off
     {{- end }}

--- a/charts/livy/livy-chart/values.yaml
+++ b/charts/livy/livy-chart/values.yaml
@@ -4,6 +4,8 @@
 
 replicaCount: 1
 
+livyVersion: 0.7.0
+
 image:
   # -- Image repository
   baseRepository: gcr.io/mapr-252711


### PR DESCRIPTION
Mounts like `/opt/mapr/livy/livy-{{ .Chart.AppVersion }}/logs` would not work for Livy 0.5 so we need to be able to explicitly set which Livy version is in use rather than utilizing `.Chart.AppVersion`.