### PR TITLE
EZSPA-410: Spark-HS helm chart should create NodePort service with 1 …

### DIFF
--- a/charts/spark-hs/spark-hs-chart/templates/_helpers.tpl
+++ b/charts/spark-hs/spark-hs-chart/templates/_helpers.tpl
@@ -14,23 +14,18 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
-Return HttpPortSparkHsUI
-*/}}
-{{- define "spark-hs-chart.getHttpPortSparkHsUI" -}}
-{{- $httpPortSparkHsUI := .Values.ports.httpPort -}}
-{{- if(not .Values.tenantIsUnsecure)  -}}
-{{- $httpPortSparkHsUI = .Values.ports.httpsPort -}}
-{{- end -}}
-{{ print $httpPortSparkHsUI }}
-{{- end -}}
-
-{{/*
 Return ports
 */}}
 {{- define "spark-hs-chart.ports" -}}
+{{-  if  or  ( not .Values.tenantIsUnsecure) (.Values.useCustomSSL)  }}
+- name: "https"
+  containerPort: {{ .Values.ports.httpsPort }}
+  protocol: TCP
+{{ else }}
 - name: "http"
-  protocol: "TCP"
-  containerPort: {{ include "spark-hs-chart.getHttpPortSparkHsUI" . }}
+  containerPort: {{ .Values.ports.httpPort }}
+  protocol: TCP
+{{- end }}
 - name: "ssh"
   protocol: "TCP"
   containerPort: {{ .Values.ports.sshPort }}
@@ -124,4 +119,3 @@ Returns a list of extra spark conf items
     {{- end }}
     {{ println }}
 {{- end }}
-

--- a/charts/spark-hs/spark-hs-chart/templates/service.yaml
+++ b/charts/spark-hs/spark-hs-chart/templates/service.yaml
@@ -13,13 +13,16 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - name: http
-      port: {{ .Values.ports.httpPort }}
-      targetPort: {{ .Values.ports.httpPort }}
-      protocol: TCP
+    {{-  if  or  ( not .Values.tenantIsUnsecure) (.Values.useCustomSSL)  }}
     - name: https
       port: {{ .Values.ports.httpsPort }}
       targetPort: {{ .Values.ports.httpsPort }}
       protocol: TCP
+    {{ else }}
+    - name: http
+      port: {{ .Values.ports.httpPort }}
+      targetPort: {{ .Values.ports.httpPort }}
+      protocol: TCP
+    {{- end }}
   selector:
     {{- include "common.selectorLabels" (dict "componentName" .Chart.Name ) | nindent 4 }}

--- a/charts/spark-hs/spark-hs-chart/values.yaml
+++ b/charts/spark-hs/spark-hs-chart/values.yaml
@@ -51,6 +51,9 @@ sparkVersion: spark-3.1.2
 #HPE tenant namespace info
 tenantIsUnsecure: false
 
+# set this only when tenant is unsecure and custom SSL is present
+useCustomSSL: false
+
 #HPE tenant namespace service account
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
…port instead of 2