### PR TITLE
Changes to Service port names to be compatible with ECP.

### DIFF
--- a/charts/livy/livy-chart/templates/service.yaml
+++ b/charts/livy/livy-chart/templates/service.yaml
@@ -16,6 +16,6 @@ spec:
     - port: {{ .Values.ports.livyHttpPort }}
       targetPort: {{ .Values.ports.livyHttpPort }}
       protocol: TCP
-      name: http
+      name: http-livy
   selector:
     {{- include "common.selectorLabels" (dict "componentName" ( include "livy-chart.name" . ) ) | nindent 4 }}

--- a/charts/spark-hs/spark-hs-chart/templates/service.yaml
+++ b/charts/spark-hs/spark-hs-chart/templates/service.yaml
@@ -14,12 +14,12 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     {{-  if  or  ( not .Values.tenantIsUnsecure) (.Values.useCustomSSL)  }}
-    - name: https
+    - name: https-sparkhs
       port: {{ .Values.ports.httpsPort }}
       targetPort: {{ .Values.ports.httpsPort }}
       protocol: TCP
     {{ else }}
-    - name: http
+    - name: http-sparkhs
       port: {{ .Values.ports.httpPort }}
       targetPort: {{ .Values.ports.httpPort }}
       protocol: TCP

--- a/charts/spark-ts/spark-ts-chart/templates/service.yaml
+++ b/charts/spark-ts/spark-ts-chart/templates/service.yaml
@@ -15,7 +15,7 @@ spec:
     - port: {{ include "spark-ts-chart.getHttpPortSparkTsUI" . }}
       targetPort: {{ include "spark-ts-chart.getHttpPortSparkTsUI" . }}
       protocol: TCP
-      name: http
+      name: http-thrift
     - port: {{ .Values.ports.sparkTsPort }}
       targetPort: {{ .Values.ports.sparkTsPort }}
       protocol: TCP


### PR DESCRIPTION
ECP UI requires service port names in the format: 'http-foo' or 'https-foo' for the ECP agent to recognize them as clickable links. This commit addresses this issue.