### PR TITLE
EZSPA-502

### DIFF
--- a/charts/spark-operator/spark-operator-chart/templates/_helpers.tpl
+++ b/charts/spark-operator/spark-operator-chart/templates/_helpers.tpl
@@ -73,3 +73,31 @@ Create the name of the service account to be used by spark apps
     {{ default "default" .Values.serviceAccounts.spark.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the webhook Init pod
+*/}}
+{{- define "spark-operator.webhookInitName" -}}
+    {{- printf "%s-webhook-init" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the webhook
+*/}}
+{{- define "spark-operator.webhookName" -}}
+    {{- printf "%s-webhook" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the webhook config
+*/}}
+{{- define "spark-operator.webhookConfigName" -}}
+    {{- printf "%s-webhook-config" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the webhook cleanup pod
+*/}}
+{{- define "spark-operator.webhookCleanUpName" -}}
+    {{- printf "%s-webhook-cleanup" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/spark-operator/spark-operator-chart/templates/deployment.yaml
+++ b/charts/spark-operator/spark-operator-chart/templates/deployment.yaml
@@ -75,8 +75,8 @@ spec:
         - -enable-webhook=true
         - -webhook-svc-namespace={{ .Release.Namespace }}
         - -webhook-port={{ .Values.webhook.port }}
-        - -webhook-svc-name={{ include "spark-operator.fullname" . }}-webhook
-        - -webhook-config-name={{ include "spark-operator.fullname" . }}-webhook-config
+        - -webhook-svc-name={{ include "spark-operator.webhookName" . }}
+        - -webhook-config-name={{ include "spark-operator.webhookConfigName" . }}
         - -webhook-namespace-selector={{ .Values.webhook.namespaceSelector }}
         {{- end }}
         - -enable-resource-quota-enforcement={{ .Values.resourceQuotaEnforcement.enable }}

--- a/charts/spark-operator/spark-operator-chart/templates/webhook-cleanup-job.yaml
+++ b/charts/spark-operator/spark-operator-chart/templates/webhook-cleanup-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "spark-operator.fullname" . }}-webhook-cleanup
+  name: {{ include "spark-operator.webhookCleanUpName" . }}
   annotations:
     "helm.sh/hook": pre-delete, pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -16,7 +16,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: {{ include "spark-operator.fullname" . }}-webhook-cleanup
+      name: {{ include "spark-operator.webhookCleanUpName" . }}
       {{- if .Values.istio.enabled }}
       annotations:
         "sidecar.istio.io/inject": "false"
@@ -50,7 +50,7 @@ spec:
           -H \"Accept: application/json\" \
           -H \"Content-Type: application/json\" \
           --data \"{\\\"kind\\\":\\\"DeleteOptions\\\",\\\"apiVersion\\\":\\\"batch/v1\\\",\\\"propagationPolicy\\\":\\\"Foreground\\\"}\" \
-          https://kubernetes.default.svc/apis/batch/v1/namespaces/{{ .Release.Namespace }}/jobs/{{ include "spark-operator.fullname" . }}-webhook-init"
+          https://kubernetes.default.svc/apis/batch/v1/namespaces/{{ .Release.Namespace }}/jobs/{{ include "spark-operator.webhookInitName" . }}"
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
 {{ end }}

--- a/charts/spark-operator/spark-operator-chart/templates/webhook-init-job.yaml
+++ b/charts/spark-operator/spark-operator-chart/templates/webhook-init-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "spark-operator.fullname" . }}-webhook-init
+  name: {{  include "spark-operator.webhookInitName" . }}
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
   {{- if .Values.ownerReference.overRide }}
@@ -13,7 +13,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: {{ include "spark-operator.fullname" . }}-webhook-init
+      name: {{ include "spark-operator.webhookInitName" . }}
       {{- if .Values.istio.enabled }}
       annotations:
         "sidecar.istio.io/inject": "false"
@@ -31,7 +31,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        command: ["/usr/bin/gencerts.sh", "-n", "{{ .Release.Namespace }}", "-s", "{{ include "spark-operator.fullname" . }}-webhook", "-p"]
+        command: ["/usr/bin/gencerts.sh", "-n", "{{ .Release.Namespace }}", "-s", "{{ include "spark-operator.webhookName" . }}", "-p"]
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
 {{ end }}

--- a/charts/spark-operator/spark-operator-chart/templates/webhook-service.yaml
+++ b/charts/spark-operator/spark-operator-chart/templates/webhook-service.yaml
@@ -2,7 +2,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ include "spark-operator.fullname" . }}-webhook
+  name: {{ include "spark-operator.webhookName" . }}
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
   {{- if .Values.ownerReference.overRide }}


### PR DESCRIPTION
- Fixed a bug where webhook name greater than 64 chars causes secret creation error
- Truncating webhook names and wrapped webhook names in helper functions.