### PR TITLE
Update example to include extraClassPath to dtap jar

### DIFF
--- a/examples/spark-2.4.7/spark-dtap-wc.yaml
+++ b/examples/spark-2.4.7/spark-dtap-wc.yaml
@@ -32,6 +32,8 @@ spec:
     spark.hadoop.fs.dtap.impl: "com.bluedata.hadoop.bdfs.Bdfs"
     spark.hadoop.fs.AbstractFileSystem.dtap.impl: "com.bluedata.hadoop.bdfs.BdAbstractFS"
     spark.hadoop.fs.dtap.impl.disable.cache: "false"
+    spark.driver.extraClassPath: "/opt/bdfs/bluedata-dtap.jar"
+    spark.executor.extraClassPath: "/opt/bdfs/bluedata-dtap.jar"
   type: Java
   sparkVersion: 2.4.7
   mode: cluster


### PR DESCRIPTION
In order for dtap:// references in deps to work,  the extraClassPath to the dtap jar for spark driver and executor is needed - otherwise, the driver pod gives the error
Exception in thread "main" java.lang.RuntimeException: java.lang.ClassNotFoundException: Class com.bluedata.hadoop.bdfs.Bdfs not found