### PR TITLE
reverting livy config mount path to match config path in image

### DIFF
--- a/charts/livy/livy-chart/templates/_helpers.tpl
+++ b/charts/livy/livy-chart/templates/_helpers.tpl
@@ -161,7 +161,7 @@ return volume mounts for containers
   mountPath: {{ .Values.livySsl.secretMountPath }}
 {{- end }}
 - name: livy-extra-configs
-  mountPath: /opt/mapr/kubernetes/{{ include "livy-chart.secretName" . }}
+  mountPath: /opt/mapr/kubernetes/livy-secret-configs
 - name: logs
   mountPath: /opt/mapr/livy/livy-{{ include "livy-chart.livyVersion" . }}/logs
 {{- end }}


### PR DESCRIPTION
A recent change accidentally broke the ability to read custom configuration for Livy and Spark, this PR reverts the mount path to match the one in the image. 