### PR TITLE
EZSPA-811

### DIFF
--- a/charts/livy/livy-chart/templates/_helpers.tpl
+++ b/charts/livy/livy-chart/templates/_helpers.tpl
@@ -41,7 +41,7 @@ Create chart name and version as used by the chart label.
 All livy labels
 */}}
 {{- define "livy-chart.labels" -}}
-{{ include "common.labels" (dict "componentName" ( include "livy-chart.componentName" . ) "namespace" .Release.Namespace) }}
+{{ include "common.labels" (dict "componentName" ( printf "%s-svc" (include "livy-chart.componentName" .) ) "namespace" .Release.Namespace) }}
 helm.sh/chart: {{ include "livy-chart.chart" . }}
 {{ include "livy-chart.selectorLabels" . }}
 app.kubernetes.io/version: {{ include "livy-chart.livyVersion" . | quote }}
@@ -49,13 +49,13 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
-Evaluates component service name based on component type
+Evaluates component name based on component type
 */}}
 {{- define "livy-chart.componentName" -}}
 {{ if eq .Values.image.imageName "livy-0.7.0" }}
-{{- print "livy-070-svc" -}}
+{{- print "livy-070" -}}
 {{ else }}
-{{- print "livy-070-247-svc" -}}
+{{- print "livy-070-247" -}}
 {{- end }}
 {{- end }}
 

--- a/charts/livy/livy-chart/templates/_helpers.tpl
+++ b/charts/livy/livy-chart/templates/_helpers.tpl
@@ -38,13 +38,25 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
-Common labels
+All livy labels
 */}}
 {{- define "livy-chart.labels" -}}
+{{ include "common.labels" (dict "componentName" ( include "livy-chart.componentName" . ) "namespace" .Release.Namespace) }}
 helm.sh/chart: {{ include "livy-chart.chart" . }}
 {{ include "livy-chart.selectorLabels" . }}
 app.kubernetes.io/version: {{ include "livy-chart.livyVersion" . | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Evaluates component service name based on component type
+*/}}
+{{- define "livy-chart.componentName" -}}
+{{ if eq .Values.image.imageName "livy-0.7.0" }}
+{{- print "livy-070-svc" -}}
+{{ else }}
+{{- print "livy-070-247-svc" -}}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/livy/livy-chart/templates/configmap.yaml
+++ b/charts/livy/livy-chart/templates/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- end }}
   {{- end }}
   labels:
-  {{- include "common.labels" (dict "componentName" ( include "livy-chart.configmapName" . ) "namespace" .Release.Namespace ) | nindent 4 }}
+  {{- include "livy-chart.labels" . | nindent 4 }}
 data:
   livy-client.conf: |
     # Environment variables here would be replaced by its values

--- a/charts/livy/livy-chart/templates/rbac.yaml
+++ b/charts/livy/livy-chart/templates/rbac.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- end }}
   {{- end }}
   labels:
-  {{- include "common.labels" (dict "componentName" ( include "livy-chart.roleName" . ) "namespace" .Release.Namespace ) | nindent 4 }}
+  {{- include "livy-chart.labels" . | nindent 4 }}
 rules:
 - apiGroups:
     - ""
@@ -34,7 +34,7 @@ metadata:
   {{- end }}
   {{- end }}
   labels:
-  {{- include "common.labels" (dict "componentName" ( include "livy-chart.roleBindingName" . ) "namespace" .Release.Namespace ) | nindent 4 }}
+  {{- include "livy-chart.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/livy/livy-chart/templates/service.yaml
+++ b/charts/livy/livy-chart/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- end }}
   {{- end }}
   labels:
-    {{- include "common.labels" (dict "componentName" ( include "livy-chart.serviceName" . ) "namespace" .Release.Namespace ) | nindent 4 }}
+    {{- include "livy-chart.labels" . | nindent 4 }}
 spec:
   type: NodePort
   sessionAffinity: ClientIP
@@ -22,4 +22,4 @@ spec:
       name: http-livy
       {{- end }}
   selector:
-    {{- include "common.selectorLabels" (dict "componentName" ( include "livy-chart.name" . ) ) | nindent 4 }}
+    {{- include "livy-chart.selectorLabels" . | nindent 4 }}

--- a/charts/livy/livy-chart/templates/serviceaccount.yaml
+++ b/charts/livy/livy-chart/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "livy-chart.serviceAccountName" . }}
   labels:
-  {{- include "common.labels" (dict "componentName" ( include "livy-chart.serviceAccountName" . ) "namespace" .Release.Namespace ) | nindent 4 }}
+  {{- include "livy-chart.labels" . | nindent 4 }}
   {{- if .Values.ownerReference.overRide }}
   {{- with .Values.ownerReference.ownerReferences }}
   ownerReferences: {{- toYaml . | nindent 2 }}

--- a/charts/livy/livy-chart/templates/statefulset.yaml
+++ b/charts/livy/livy-chart/templates/statefulset.yaml
@@ -11,12 +11,12 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-    {{- include "common.selectorLabels" (dict "componentName" ( include "livy-chart.name" . ) ) | nindent 6 }}
+    {{- include "livy-chart.selectorLabels" . | nindent 6 }}
   serviceName: {{ include "livy-chart.serviceName" . }}
   template:
     metadata:
       labels:
-      {{- include "common.labels" (dict "componentName" ( include "livy-chart.name" . ) "namespace" .Release.Namespace ) | nindent 8 }}
+      {{- include "livy-chart.labels" . | nindent 8 }}
     spec:
       subdomain: livy-svc
       affinity:


### PR DESCRIPTION
- use 'hpe.com/component' label to contain component type, not component name