### PR TITLE
EZSPA-876 - helm installation is failing for spark ts

### DIFF
--- a/charts/spark-ts/spark-ts-chart/templates/_helpers.tpl
+++ b/charts/spark-ts/spark-ts-chart/templates/_helpers.tpl
@@ -135,5 +135,9 @@ Returns role binding name
 Returns a list of extra spark conf items
 */}}
 {{- define "spark-ts-chart.extraConfigs" -}}
+{{- if not (empty .Values.sparkExtraConfigs)  -}}
     {{ .Values.sparkExtraConfigs }}
+{{- else -}}
+   # Secret configs are empty
+{{- end -}}
 {{- end }}


### PR DESCRIPTION
If sparkExtraConfigs is empty, helm install fails. This PR fixes that