### PR TITLE
EZAF-414 Integrate ranger with DF as a PV

### DIFF
--- a/charts/ranger/ranger-chart/files/fresh-install-ranger.sh
+++ b/charts/ranger/ranger-chart/files/fresh-install-ranger.sh
@@ -4,16 +4,6 @@ ns="${1:-ranger}"
 
 echo NameSpace: $ns
 
-echo Making sub-directories for MYSQL /nfs/$ns/mysql-pv
-mkdir -p /nfs/$ns/mysql-pv >/dev/null 2>&1
-chmod 777 /nfs/$ns/mysql-pv
-
-echo chmod -R 777 /nfs/$ns
-chmod -R 777 /nfs/$ns
-
-echo tree /nfs/$ns
-tree /nfs/$ns
-
 echo helm install ranger ./ranger --namespace $ns --create-namespace --wait
 helm install ranger ./ranger-chart --namespace $ns --create-namespace --wait
 echo kubectl get all -n $ns

--- a/charts/ranger/ranger-chart/files/full-cleanup.sh
+++ b/charts/ranger/ranger-chart/files/full-cleanup.sh
@@ -9,11 +9,6 @@ helm uninstall ranger -n $ns
 echo kubectl delete pvc --all -n $ns
 kubectl delete pvc --all -n $ns
 
-cdir="/nfs/$ns/mysql-pv"
-sudo rm -rf $cdir/*
-
-tree /nfs/$ns
-
 echo kubectl get all -n $ns
 kubectl get all -n $ns
 

--- a/charts/ranger/ranger-chart/templates/mysql/mysql-deployment.yaml
+++ b/charts/ranger/ranger-chart/templates/mysql/mysql-deployment.yaml
@@ -54,7 +54,8 @@ spec:
         app: {{ .label }}
     spec:
       securityContext:
-        runAsUser: 999
+        # UID must be 5000 (mapr) to work well with DF
+        runAsUser: 5000
         #runAsGroup: 0
         fsGroup: 0            
         #runAsNonRoot: true

--- a/charts/ranger/ranger-chart/templates/mysql/mysql-pv.yaml
+++ b/charts/ranger/ranger-chart/templates/mysql/mysql-pv.yaml
@@ -1,4 +1,5 @@
 {{- with .Values.dataStore.storage }}
+{{ if eq .isNfs true }}
 
 apiVersion: v1
 kind: PersistentVolume
@@ -17,6 +18,7 @@ spec:
     server: {{ .serverIp }}
     path: {{ tpl (.storagePath) $ | quote }}
       
+{{ end }}
 {{- end }}
 
 ---

--- a/charts/ranger/ranger-chart/values.yaml
+++ b/charts/ranger/ranger-chart/values.yaml
@@ -22,11 +22,18 @@ dataStore:
   listenPort: 3306
   label: mysql
 
+  # Your persistent provider can be either NFS or DF
+  # a) to enable NFS mode, please set isNfs=true and provide NFS serverIp
+  # b) to enable DF mode, please provide a correct storageClassName. It can be found by issuing:
+  # kubectl get sc | grep com.mapr.csi-kdf | tr -s ' ' | cut -f 1 -d ' ' | tail +1
+  # Default configuration would be DF, assuming your DF cluster name is cluster.qa.lab
+  # NOTE: with NFS case your data won't be cleaned up after uninstalling. WIth DF case it will be
   storage:
+    isNfs: true
     serverIp: 16.0.13.105
     pvFullname: "{{ .Release.Namespace }}-{{ .Values.kind.persistentVolumes }}-mysql"
     pvcFullname: "{{ .Release.Namespace }}-{{ .Values.kind.persistentVolumeClaim }}-mysql"
-    storageClassName: "{{ .Release.Namespace }}-manual-mysql"
+    storageClassName: "cluster-qa-lab"
     storagePath: /nfs/{{ .Release.Namespace }}/mysql-pv/
     accessMode: ReadWriteMany
     size: 5Gi


### PR DESCRIPTION
As a result of this PR:
- NFS is no longer mandatory thing to deploy ranger, it would be optional
- instead, you can use DF as a persistent provider
- thus, all the steps provided in "Tips" document can be executed from everywhere (f.e. your local laptop)
- if NFS is enabled, DB data won't be cleaned up after uninstall and/or full-cleanup.sh
- unlike DF. If it is enabled, data will be removed after uninstall (we might want to change this in scope of another issue)