### PR TITLE
EZAF-1056: Labels should be added through configmap instead of hardco…

### DIFF
--- a/charts/spark-operator/spark-operator-chart/templates/_helpers.tpl
+++ b/charts/spark-operator/spark-operator-chart/templates/_helpers.tpl
@@ -184,14 +184,6 @@ return podAntiAffinity for autoticket generator components
 {{- end }}
 
 {{/*
-return labels for autotix-cm to be added to spark jobs
-*/}}
-{{- define "autoticket-generator.sparkLabels" -}}
-hpe-ezua/app: {{ .Values.autotix.sparkAppLabels.hpeezuaApp }}
-hpe-ezua/type: {{ .Values.autotix.sparkAppLabels.hpeezuaType }}
-{{- end }}
-
-{{/*
 return env for autoticket-generator container
 */}}
 {{- define "autoticket-generator.env" -}}

--- a/charts/spark-operator/spark-operator-chart/templates/_helpers.tpl
+++ b/charts/spark-operator/spark-operator-chart/templates/_helpers.tpl
@@ -184,6 +184,14 @@ return podAntiAffinity for autoticket generator components
 {{- end }}
 
 {{/*
+return labels for autotix-cm to be added to spark jobs
+*/}}
+{{- define "autoticket-generator.sparkLabels" -}}
+hpe-ezua/app: spark
+hpe-ezua/type: app-service-user
+{{- end }}
+
+{{/*
 return env for autoticket-generator container
 */}}
 {{- define "autoticket-generator.env" -}}

--- a/charts/spark-operator/spark-operator-chart/templates/_helpers.tpl
+++ b/charts/spark-operator/spark-operator-chart/templates/_helpers.tpl
@@ -148,6 +148,12 @@ Create the name of the autoticket generator cleanup pod
     {{- printf "%s-autotix-cleanup" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*Create a autoticket generator configmap name
+*/}}
+{{- define "autoticket-generator.sparkLabelconfigMapName" -}}
+{{- printf "%s" .Values.autotix.sparkLabelConfigName  | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
 {{/*Create a autoticket generator service name
 */}}
 {{- define "autoticket-generator.svcName" -}}

--- a/charts/spark-operator/spark-operator-chart/templates/_helpers.tpl
+++ b/charts/spark-operator/spark-operator-chart/templates/_helpers.tpl
@@ -187,8 +187,8 @@ return podAntiAffinity for autoticket generator components
 return labels for autotix-cm to be added to spark jobs
 */}}
 {{- define "autoticket-generator.sparkLabels" -}}
-hpe-ezua/app: spark
-hpe-ezua/type: app-service-user
+hpe-ezua/app: {{ .Values.autotix.sparkAppLabels.hpeezuaApp }}
+hpe-ezua/type: {{ .Values.autotix.sparkAppLabels.hpeezuaType }}
 {{- end }}
 
 {{/*

--- a/charts/spark-operator/spark-operator-chart/templates/_helpers.tpl
+++ b/charts/spark-operator/spark-operator-chart/templates/_helpers.tpl
@@ -221,6 +221,6 @@ return volumeMounts for autoticket-generator container
   mountPath:  /opt/validator/certs
   readOnly: true
 - name: autoticket-generator-cm
-  mountPath:  /opt/autotix
+  mountPath:  /opt/autotix/conf
   readOnly: true
 {{- end }}

--- a/charts/spark-operator/spark-operator-chart/templates/_helpers.tpl
+++ b/charts/spark-operator/spark-operator-chart/templates/_helpers.tpl
@@ -150,8 +150,8 @@ Create the name of the autoticket generator cleanup pod
 
 {{/*Create a autoticket generator configmap name
 */}}
-{{- define "autoticket-generator.sparkLabelconfigMapName" -}}
-{{- printf "%s" .Values.autotix.sparkLabelConfigName  | trunc 63 | trimSuffix "-" }}
+{{- define "autoticket-generator.configMapName" -}}
+{{- printf "%s-%s" .Values.autotix.autotixName "cm"  | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*Create a autoticket generator service name
@@ -200,6 +200,9 @@ return volume for autoticket-generator container
 - name: autoticket-generator-certs
   secret:
     secretName: autoticket-generator-certs
+- name: autoticket-generator-cm
+  configMap:
+    name: {{ include "autoticket-generator.configMapName" . }}
 {{- end }}
 
 {{/*
@@ -208,5 +211,8 @@ return volumeMounts for autoticket-generator container
 {{- define "autoticket-generator.volumesMounts" -}}
 - name: autoticket-generator-certs
   mountPath:  /opt/validator/certs
+  readOnly: true
+- name: autoticket-generator-cm
+  mountPath:  /opt/autotix
   readOnly: true
 {{- end }}

--- a/charts/spark-operator/spark-operator-chart/templates/autotix-cm.yaml
+++ b/charts/spark-operator/spark-operator-chart/templates/autotix-cm.yaml
@@ -12,6 +12,5 @@ metadata:
     {{- end }}
 data:
   spark_app_labels.yaml: |
-    hpe-ezua/app: spark
-    hpe-ezua/type: app-service-user
+    {{- include "autoticket-generator.sparkLabels" . | nindent 4 }}
   {{ end }}

--- a/charts/spark-operator/spark-operator-chart/templates/autotix-cm.yaml
+++ b/charts/spark-operator/spark-operator-chart/templates/autotix-cm.yaml
@@ -12,5 +12,5 @@ metadata:
     {{- end }}
 data:
   spark_app_labels.yaml: |
-    {{- include "autoticket-generator.sparkLabels" . | nindent 4 }}
+    {{- toYaml .Values.autotix.sparkAppLabels | nindent 4 }}
   {{ end }}

--- a/charts/spark-operator/spark-operator-chart/templates/autotix-cm.yaml
+++ b/charts/spark-operator/spark-operator-chart/templates/autotix-cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "autoticket-generator.sparkLabelconfigMapName" . }}
+  name: {{ include "autoticket-generator.configMapName" . }}
   labels:
   {{- include "autoticket-generator.selectorLabels" . | nindent 4 }}
   {{- if .Values.ownerReference.overRide }}
@@ -11,6 +11,7 @@ metadata:
     {{- end }}
     {{- end }}
 data:
-    label_1: "hpe-ezua/app: spark"
-    lable_2: "hpe-ezua/type: app-service-user"
+  spark_app_labels.yaml: |
+    hpe-ezua/app: spark
+    hpe-ezua/type: app-service-user
   {{ end }}

--- a/charts/spark-operator/spark-operator-chart/templates/autotix-sparkLabel-cm.yaml
+++ b/charts/spark-operator/spark-operator-chart/templates/autotix-sparkLabel-cm.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.autotix.enable }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "autoticket-generator.sparkLabelconfigMapName" . }}
+  labels:
+  {{- include "autoticket-generator.selectorLabels" . | nindent 4 }}
+  {{- if .Values.ownerReference.overRide }}
+  {{- with  .Values.ownerReference.ownerReferences }}
+  ownerReferences: {{- toYaml . | nindent 2 }}
+    {{- end }}
+    {{- end }}
+data:
+    label_1: "hpe-ezua/app: spark"
+    lable_2: "hpe-ezua/type: app-service-user"
+  {{ end }}

--- a/charts/spark-operator/spark-operator-chart/values.yaml
+++ b/charts/spark-operator/spark-operator-chart/values.yaml
@@ -18,7 +18,7 @@ image:
   # -- Image name for autotix
   autotixImageName: autoticketgen-1.0.0
   # -- Image tag for autotix
-  autotixTag: "202303141935AJ"
+  autotixTag: "202303162153AJ"
 
 # -- Image pull secrets
 imagePullSecrets:

--- a/charts/spark-operator/spark-operator-chart/values.yaml
+++ b/charts/spark-operator/spark-operator-chart/values.yaml
@@ -108,6 +108,10 @@ autotix:
       cpu: 500m
   # add env variable to add labels for observability -- default is set to true
   configureLabel: true
+  # labels for observability
+  sparkAppLabels:
+    hpeezuaApp: spark
+    hpeezuaType: app-service-user
 
 metrics:
   # -- Enable prometheus metric scraping

--- a/charts/spark-operator/spark-operator-chart/values.yaml
+++ b/charts/spark-operator/spark-operator-chart/values.yaml
@@ -110,8 +110,8 @@ autotix:
   configureLabel: true
   # labels for observability
   sparkAppLabels:
-    hpeezuaApp: spark
-    hpeezuaType: app-service-user
+    "hpe-ezua/app": "spark"
+    "hpe-ezua/type": "app-service-user"
 
 metrics:
   # -- Enable prometheus metric scraping

--- a/charts/spark-operator/spark-operator-chart/values.yaml
+++ b/charts/spark-operator/spark-operator-chart/values.yaml
@@ -110,8 +110,8 @@ autotix:
   configureLabel: true
   # labels for observability
   sparkAppLabels:
-    "hpe-ezua/app": "spark"
-    "hpe-ezua/type": "app-service-user"
+    #"hpe-ezua/app": "spark"
+    #"hpe-ezua/type": "app-service-user"
 
 metrics:
   # -- Enable prometheus metric scraping

--- a/charts/spark-operator/spark-operator-chart/values.yaml
+++ b/charts/spark-operator/spark-operator-chart/values.yaml
@@ -18,7 +18,7 @@ image:
   # -- Image name for autotix
   autotixImageName: autoticketgen-1.0.0
   # -- Image tag for autotix
-  autotixTag: "202303080925AJ"
+  autotixTag: "202303141935AJ"
 
 # -- Image pull secrets
 imagePullSecrets:
@@ -93,8 +93,6 @@ autotix:
   enable: false
   # -- String autoticket-generator name
   autotixName: "autoticket-generator"
-  #spark label addition configmap name
-  sparkLabelConfigName : "sparklabels-cm"
   # -- ports for autoticket generator service
   port: 443
   targetPort: 8443

--- a/charts/spark-operator/spark-operator-chart/values.yaml
+++ b/charts/spark-operator/spark-operator-chart/values.yaml
@@ -93,6 +93,8 @@ autotix:
   enable: false
   # -- String autoticket-generator name
   autotixName: "autoticket-generator"
+  #spark label addition configmap name
+  sparkLabelConfigName : "sparklabels-cm"
   # -- ports for autoticket generator service
   port: 443
   targetPort: 8443


### PR DESCRIPTION
…ding the labels in the code

    Using configmap to add labels to spark applications for observability instead of hardcoding them.
    Configmap data is in the form of  label_1: "hpe-ezua/app: spark" as / is not allowed in the string used as key.