### PR TITLE
EZAF-3004: Use release version of EEP spark-3.4.1 in EZAF

### DIFF
--- a/charts/livy/livy-chart/values.yaml
+++ b/charts/livy/livy-chart/values.yaml
@@ -16,9 +16,9 @@ image:
   pullPolicy: Always
 
 #default spark image for spark applications created with livy
-deImage: spark-3.4.1:202308221003R
+deImage: spark-3.4.1:202309070600R
 #for livy-0.7.0/spark-2.4.7
-#deImage: spark-2.4.7:202308221003R
+#deImage: spark-2.4.7:202309070600R
 
 # -- Whether to create a default pull secret
 createDefaultPullSecret: false

--- a/charts/spark-hs/spark-hs-chart/values.yaml
+++ b/charts/spark-hs/spark-hs-chart/values.yaml
@@ -17,7 +17,7 @@ image:
   pullPolicy: Always
   # -- Overrides the image tag whose default is the chart appVersion.
   # -- Image tag
-  tag: "202308221003R"
+  tag: "202309070600R"
 
 # -- Whether to create a default pull secret
 createDefaultPullSecret: false


### PR DESCRIPTION
As release version of EEP Spark v3.4.1 packages are ready, we are upgrading corresponding helm charts.

PS: New images are tagged as v3.4.1 as well https://console.cloud.google.com/gcr/images/mapr-252711/global/spark-3.4.1?authuser=1&project=mapr-252711