### PR TITLE
EZAF-3280 - Tenant operator removes annotations and owner reference from namespace

### DIFF
--- a/charts/tenant-operator/Chart.yaml
+++ b/charts/tenant-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tenantoperator
 description: A Helm chart for Kubernetes
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: "1.0.0"

--- a/charts/tenant-operator/values.yaml
+++ b/charts/tenant-operator/values.yaml
@@ -8,7 +8,7 @@ image:
   baseRepository: gcr.io/mapr-252711
   operatorImageName: tenantoperator-1.0.0
   pullPolicy: Always
-  operatorTag: "202204141412P151"
+  operatorTag: "202310061227MG"
   validatorImageName: tenantvalidator-1.0.0
   validatorTag: "202305160914AJ"
 


### PR DESCRIPTION
updated image tag for tenant operator