### PR TITLE
Enable to start Livy Sessions user namespaces

### DIFF
--- a/charts/livy/livy-chart/Chart.yaml
+++ b/charts/livy/livy-chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: livy
 description: A Helm chart for apache livy
 type: application
-version: 0.4.6
+version: 0.4.7
 appVersion: "0.8.0.0"
 dependencies:
   - name: common

--- a/charts/livy/livy-chart/templates/_helpers.tpl
+++ b/charts/livy/livy-chart/templates/_helpers.tpl
@@ -95,7 +95,7 @@ Return ports
 Create the name of the service account to use
 */}}
 {{- define "livy-chart.serviceAccountName" -}}
-{{- if ( and ( not .Values.serviceAccount.create ) ( not ( empty .Values.serviceAccount.name)) ) -}}
+{{- if ( and ( .Values.serviceAccount.create ) ( not ( empty .Values.serviceAccount.name)) ) -}}
     {{- .Values.serviceAccount.name }}
 {{- else -}}
     hpe-{{ .Release.Namespace }}

--- a/charts/livy/livy-chart/templates/rbac.yaml
+++ b/charts/livy/livy-chart/templates/rbac.yaml
@@ -1,7 +1,7 @@
 ---
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: {{ include "livy-chart.roleName" . }}
   {{- if .Values.ownerReference.overRide }}
@@ -18,6 +18,7 @@ rules:
     - configmaps
     - pods
     - services
+    - secrets
   verbs:
     - "*"
 {{- end }}
@@ -25,7 +26,7 @@ rules:
 ---
 {{- if and .Values.rbac.create .Values.serviceAccount.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: {{ include "livy-chart.roleBindingName" . }}
   {{- if .Values.ownerReference.overRide }}
@@ -37,9 +38,10 @@ metadata:
   {{- include "livy-chart.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: {{ include "livy-chart.roleName" . }}
 subjects:
 - name: {{ include "livy-chart.serviceAccountName" . }}
   kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/livy/livy-chart/values.yaml
+++ b/charts/livy/livy-chart/values.yaml
@@ -11,7 +11,7 @@ image:
   imageName: livy-0.8.0
   # imageName: livy-0.8.0-2.4.7
   # -- Overrides the image tag whose default is the chart appVersion.
-  tag: "202312050400R"
+  tag: "202312150949R"
   # -- Image pull policy
   pullPolicy: Always
 

--- a/charts/livy/livy-chart/values.yaml
+++ b/charts/livy/livy-chart/values.yaml
@@ -47,17 +47,17 @@ tenantIsUnsecure: false
 serviceAccount:
   # Specifies whether a service account should be created
   # Default Service account is hpe-{{ ReleaseNamespace }}, which is created by Tenant operator.
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use. Please only use the tenant Service Account
   # This name is used only when create ServiceAccount option is set to true.
-  name: ""
+  name: "livy-server-sa"
 
 #Create RBAC for the Service Account
 rbac:
   #RBAC is created only when this flag is true and ServiceAccount.create is also true
-  create: false
+  create: true
 
 podSecurityContext: {}
 
@@ -135,6 +135,9 @@ extraConfigs:
     # livy.keystore = /var/livy/ssl_keystore
     # livy.keystore.password = examplepass
     # livy.key-password = examplepass
+  spark-defaults.conf: |
+    spark.kubernetes.driver.label.sidecar.istio.io/inject=false
+    spark.kubernetes.executor.label.sidecar.istio.io/inject=false
 
 # istio-related settings
 istio:


### PR DESCRIPTION
* replace namespaced RBACs with cluster-level ones to allow livy server access livy sessions in other namespaces
* disable istio injection explicitly for spawned spark driver/executor pods
* fix livy server service account evaluation