### PR TITLE
EZAF-4723 - User/Shared volumes is not mounted to Spark workload after Upgrade

### DIFF
--- a/charts/spark-operator/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator/spark-operator-chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: hpe-spark-operator
 description: A Helm chart for HPE Spark on Kubernetes operator
-version: 1.3.4
-appVersion: 1.3.8.4-hpe
+version: 1.3.6
+appVersion: 1.3.8.6-hpe

--- a/charts/spark-operator/spark-operator-chart/templates/deployment.yaml
+++ b/charts/spark-operator/spark-operator-chart/templates/deployment.yaml
@@ -24,8 +24,8 @@ spec:
     type: Recreate
   template:
     metadata:
-    {{- if or .Values.podAnnotations .Values.metrics.enable }}
       annotations:
+        rollme: {{ randAlphaNum 7 | quote }}
       {{- if .Values.metrics.enable }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.metrics.port }}"
@@ -34,7 +34,6 @@ spec:
       {{- if .Values.podAnnotations }}
         {{- toYaml .Values.podAnnotations | trim | nindent 8 }}
       {{- end }}
-    {{- end }}
       labels:
         {{- include "spark-operator.selectorLabels" . | nindent 8 }}
         {{- with .Values.customLabels }}

--- a/charts/spark-operator/spark-operator-chart/values.yaml
+++ b/charts/spark-operator/spark-operator-chart/values.yaml
@@ -18,7 +18,7 @@ image:
   # -- Image name for autotix
   autotixImageName: autoticketgen-2.1.0
   # -- Image tag for autotix
-  autotixTag: "202403060009"
+  autotixTag: "202403181838"
 
 # -- Image pull secrets
 imagePullSecrets:

--- a/charts/spark-operator/spark-operator-chart/values.yaml
+++ b/charts/spark-operator/spark-operator-chart/values.yaml
@@ -12,7 +12,7 @@ image:
   # -- Image Name
   imageName: spark-operator-1.3.8
   # -- Image tag
-  tag: "1.3.8.4-hpe"
+  tag: "1.3.8.6-hpe"
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Image name for autotix


### PR DESCRIPTION
For upgrade cases when the spark-operator deployment was not changed, it will not be restarted, however new certs will be generated in any case. So, restarting of spark-operator deployment is also necessary to avoid the server using old certs.